### PR TITLE
Improve params/metrics listing in Aim UI

### DIFF
--- a/pkg/api/aim/projects.go
+++ b/pkg/api/aim/projects.go
@@ -117,7 +117,7 @@ func GetProjectParams(c *fiber.Ctx) error {
 			resp[s] = fiber.Map{}
 		case "metric":
 			var metricKeys []string
-			if tx := database.DB.Model(&database.Metric{}).Distinct().Pluck("Key", &metricKeys); tx.Error != nil {
+			if tx := database.DB.Model(&database.LatestMetric{}).Distinct().Pluck("Key", &metricKeys); tx.Error != nil {
 				return fmt.Errorf("error retrieving metric keys: %w", tx.Error)
 			}
 


### PR DESCRIPTION
We were looking in the wrong table (`metrics` instead of `latest_metrics`) to lookup the list of param/metric keys in Aim. This is a simple fix that should improve that lookup time.

In the future, we may want to consider further normalising the database and having a separate table with param/metric key names.