### PR TITLE
Expose MLFlow tags in Aim UI

### DIFF
--- a/pkg/api/aim/projects.go
+++ b/pkg/api/aim/projects.go
@@ -90,12 +90,26 @@ func GetProjectParams(c *fiber.Ctx) error {
 			return fmt.Errorf("error retrieving param keys: %w", tx.Error)
 		}
 
-		params := make(map[string]map[string]string, len(paramKeys))
+		params := make(map[string]any, len(paramKeys)+1)
 		for _, p := range paramKeys {
 			params[p] = map[string]string{
 				"__example_type__": "<class 'str'>",
 			}
 		}
+
+		var tagKeys []string
+		if tx := database.DB.Model(&database.Tag{}).Distinct().Pluck("Key", &tagKeys); tx.Error != nil {
+			return fmt.Errorf("error retrieving tag keys: %w", tx.Error)
+		}
+
+		tags := make(map[string]map[string]string, len(tagKeys))
+		for _, t := range tagKeys {
+			tags[t] = map[string]string{
+				"__example_type__": "<class 'str'>",
+			}
+		}
+
+		params["tags"] = tags
 
 		resp["params"] = params
 	}


### PR DESCRIPTION
MLFlow tags are now exposed in Aim UI as a param object named `tags`.

We'll probably want to rename Aim tags to labels (which they are, really) everywhere in the UI before we add support for those.

┆Issue is synchronized with this [Jira Task](https://gr-oss.atlassian.net/browse/FML-48) by [Unito](https://www.unito.io)
