### PR TITLE
Keep only security updates for website dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
     directory: "/website"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-name: "@docusaurus/*"
+    open-pull-requests-limit: 0 # keep only security updates and disable version updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,4 @@ updates:
     directory: "/website"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-name: "@docusaurus/*"
     open-pull-requests-limit: 0 # keep only security updates and disable version updates


### PR DESCRIPTION
To avoid being spammed, I suggest enabling only security updates for the website.