### PR TITLE
Fix offset issue in Aim API GetExperimentRuns

### DIFF
--- a/pkg/api/mlflow/dao/models/run.go
+++ b/pkg/api/mlflow/dao/models/run.go
@@ -52,7 +52,13 @@ func (rn RowNum) GormDataType() string {
 
 // GormValue implements Gorm interface for custom data types.
 func (rn RowNum) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
+	if rn == 0 {
+		return clause.Expr{
+			SQL: "(SELECT COALESCE(MAX(row_num), -1) FROM runs) + 1",
+		}
+	}
 	return clause.Expr{
-		SQL: "(SELECT COALESCE(MAX(row_num), -1) FROM runs) + 1",
+		SQL:  "?",
+		Vars: []interface{}{int64(rn)},
 	}
 }

--- a/pkg/api/mlflow/dao/models/run.go
+++ b/pkg/api/mlflow/dao/models/run.go
@@ -10,22 +10,22 @@ import (
 
 // Run represents model to work with `runs` table.
 type Run struct {
-	ID             string         `gorm:"column:run_uuid;type:varchar(32);not null;primaryKey"`
+	ID             string         `gorm:"<-:create;column:run_uuid;type:varchar(32);not null;primaryKey"`
 	Name           string         `gorm:"type:varchar(250)"`
-	SourceType     string         `gorm:"type:varchar(20);check:source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')"`
-	SourceName     string         `gorm:"type:varchar(500)"`
-	EntryPointName string         `gorm:"type:varchar(50)"`
-	UserID         string         `gorm:"type:varchar(256)"`
+	SourceType     string         `gorm:"<-:create;type:varchar(20);check:source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')"`
+	SourceName     string         `gorm:"<-:create;type:varchar(500)"`
+	EntryPointName string         `gorm:"<-:create;type:varchar(50)"`
+	UserID         string         `gorm:"<-:create;type:varchar(256)"`
 	Status         Status         `gorm:"type:varchar(9);check:status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED')"`
-	StartTime      sql.NullInt64  `gorm:"type:bigint"`
+	StartTime      sql.NullInt64  `gorm:"<-:create;type:bigint"`
 	EndTime        sql.NullInt64  `gorm:"type:bigint"`
-	SourceVersion  string         `gorm:"type:varchar(50)"`
+	SourceVersion  string         `gorm:"<-:create;type:varchar(50)"`
 	LifecycleStage LifecycleStage `gorm:"type:varchar(20);check:lifecycle_stage IN ('active', 'deleted')"`
-	ArtifactURI    string         `gorm:"type:varchar(200)"`
+	ArtifactURI    string         `gorm:"<-:create;type:varchar(200)"`
 	ExperimentID   int32
 	Experiment     Experiment
 	DeletedTime    sql.NullInt64  `gorm:"type:bigint"`
-	RowNum         RowNum         `gorm:"index"`
+	RowNum         RowNum         `gorm:"<-:create;index"`
 	Params         []Param        `gorm:"constraint:OnDelete:CASCADE"`
 	Tags           []Tag          `gorm:"constraint:OnDelete:CASCADE"`
 	Metrics        []Metric       `gorm:"constraint:OnDelete:CASCADE"`

--- a/pkg/database/model.go
+++ b/pkg/database/model.go
@@ -48,22 +48,22 @@ type ExperimentTag struct {
 }
 
 type Run struct {
-	ID             string         `gorm:"column:run_uuid;type:varchar(32);not null;primaryKey"`
+	ID             string         `gorm:"<-:create;column:run_uuid;type:varchar(32);not null;primaryKey"`
 	Name           string         `gorm:"type:varchar(250)"`
-	SourceType     string         `gorm:"type:varchar(20);check:source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')"`
-	SourceName     string         `gorm:"type:varchar(500)"`
-	EntryPointName string         `gorm:"type:varchar(50)"`
-	UserID         string         `gorm:"type:varchar(256)"`
+	SourceType     string         `gorm:"<-:create;type:varchar(20);check:source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')"`
+	SourceName     string         `gorm:"<-:create;type:varchar(500)"`
+	EntryPointName string         `gorm:"<-:create;type:varchar(50)"`
+	UserID         string         `gorm:"<-:create;type:varchar(256)"`
 	Status         Status         `gorm:"type:varchar(9);check:status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED')"`
-	StartTime      sql.NullInt64  `gorm:"type:bigint"`
+	StartTime      sql.NullInt64  `gorm:"<-:create;type:bigint"`
 	EndTime        sql.NullInt64  `gorm:"type:bigint"`
-	SourceVersion  string         `gorm:"type:varchar(50)"`
+	SourceVersion  string         `gorm:"<-:create;type:varchar(50)"`
 	LifecycleStage LifecycleStage `gorm:"type:varchar(20);check:lifecycle_stage IN ('active', 'deleted')"`
-	ArtifactURI    string         `gorm:"type:varchar(200)"`
+	ArtifactURI    string         `gorm:"<-:create;type:varchar(200)"`
 	ExperimentID   int32
 	Experiment     Experiment
 	DeletedTime    sql.NullInt64  `gorm:"type:bigint"`
-	RowNum         RowNum         `gorm:"index"`
+	RowNum         RowNum         `gorm:"<-:create;index"`
 	Params         []Param        `gorm:"constraint:OnDelete:CASCADE"`
 	Tags           []Tag          `gorm:"constraint:OnDelete:CASCADE"`
 	Metrics        []Metric       `gorm:"constraint:OnDelete:CASCADE"`

--- a/pkg/database/model.go
+++ b/pkg/database/model.go
@@ -86,8 +86,14 @@ func (rn RowNum) GormDataType() string {
 }
 
 func (rn RowNum) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
+	if rn == 0 {
+		return clause.Expr{
+			SQL: "(SELECT COALESCE(MAX(row_num), -1) FROM runs) + 1",
+		}
+	}
 	return clause.Expr{
-		SQL: "(SELECT COALESCE(MAX(row_num), -1) FROM runs) + 1",
+		SQL:  "?",
+		Vars: []interface{}{int64(rn)},
 	}
 }
 


### PR DESCRIPTION
Fixes #108.

Since the refactor, we are now trying to update too many fields in multiple places (e.g. in `UpdateRun`). This is because we used to update only the required fields but we now pass around pointers to `Run` objects.
I chose to solve this by marking the fields as create+read in Gorm annotations.