### PR TITLE
Fix broken GetMetricsHistories endpoint

### DIFF
--- a/pkg/api/mlflow/dao/repositories/metric.go
+++ b/pkg/api/mlflow/dao/repositories/metric.go
@@ -158,7 +158,7 @@ func (r MetricRepository) GetMetricHistories(
 				models.LifecycleStageDeleted,
 			})
 		}
-		if err := query.Pluck("run_uuid", runIDs).Error; err != nil {
+		if err := query.Pluck("run_uuid", &runIDs).Error; err != nil {
 			return nil, nil, eris.Wrapf(
 				err, "error getting runs by experimentIDs: %v, viewType: %s", experimentIDs, viewType,
 			)


### PR DESCRIPTION
`GetMetricsHistories` currently panics with the following stacktrace:
```
panic: reflect: reflect.Value.Set using unaddressable value
goroutine 35 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x64
github.com/gofiber/fiber/v2/middleware/recover.defaultStackTraceHandler(0x40004da900, {0x12d2780, 0x4000222410})
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/middleware/recover/recover.go:12 +0x28
github.com/gofiber/fiber/v2/middleware/recover.New.func1.1()
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/middleware/recover/recover.go:31 +0x88
panic({0x12d2780, 0x4000222410})
	/usr/local/go/src/runtime/panic.go:890 +0x21c
reflect.flag.mustBeAssignableSlow(0x97)
	/usr/local/go/src/reflect/value.go:262 +0x9c
reflect.flag.mustBeAssignable(0x97)
	/usr/local/go/src/reflect/value.go:249 +0x60
reflect.Value.Set({0x12c32a0, 0x3c5a860, 0x97}, {0x12c32a0, 0x400000e6f0, 0x97})
	/usr/local/go/src/reflect/value.go:2230 +0x38
gorm.io/gorm.Scan({0x34d2798, 0x40002d2080}, 0x40002a0a50, 0x0)
	/go/pkg/mod/gorm.io/gorm@v1.25.1/scan.go:279 +0x1414
gorm.io/gorm/callbacks.Query(0x40002a0a50)
	/go/pkg/mod/gorm.io/gorm@v1.25.1/callbacks/query.go:28 +0x204
gorm.io/gorm.(*processor).Execute(0x40002913b0, 0x40002a0a50)
	/go/pkg/mod/gorm.io/gorm@v1.25.1/callbacks.go:130 +0x5cc
gorm.io/gorm.(*DB).Pluck(0x40002a0a50, {0x12f0c3d, 0x8}, {0x12c32a0, 0x3c5a860})
	/go/pkg/mod/gorm.io/gorm@v1.25.1/finisher_api.go:569 +0x2e4
github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/repositories.MetricRepository.GetMetricHistories({{0x4000301050}}, {0x34d0ef0, 0x40004d8000}, {0x400025e040, 0x1, 0x4}, {0x0, 0x0, 0x0}, {0x0, ...}, ...)
	/workspaces/fasttrack/pkg/api/mlflow/dao/repositories/metric.go:161 +0x7c8
github.com/G-Research/fasttrackml/pkg/api/mlflow/service/metric.Service.GetMetricHistories({{0x34d17b0, 0x400059c8a0}}, {0x34d0ef0, 0x40004d8000}, 0x400059e300)
	/workspaces/fasttrack/pkg/api/mlflow/service/metric/service.go:64 +0x160
github.com/G-Research/fasttrackml/pkg/api/mlflow/controller.Controller.GetMetricHistories({0x40005b9bd0, 0x3c57e20, 0x40002d6a10, 0x40002d6a20, 0x40005915a0}, 0x40005ba2c0)
	/workspaces/fasttrack/pkg/api/mlflow/controller/metric.go:66 +0x258
github.com/gofiber/fiber/v2.(*App).next(0x40002ae900, 0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/router.go:144 +0x328
github.com/gofiber/fiber/v2.(*Ctx).Next(0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/ctx.go:913 +0xd8
github.com/gofiber/fiber/v2/middleware/logger.New.func3(0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/middleware/logger/logger.go:122 +0x3c4
github.com/gofiber/fiber/v2.(*Ctx).Next(0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/ctx.go:910 +0xb0
github.com/gofiber/fiber/v2/middleware/recover.New.func1(0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/middleware/recover/recover.go:43 +0x178
github.com/gofiber/fiber/v2.(*Ctx).Next(0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/ctx.go:910 +0xb0
github.com/gofiber/fiber/v2/middleware/compress.New.func3(0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/middleware/compress/compress.go:51 +0x84
github.com/gofiber/fiber/v2.(*App).next(0x40002ae900, 0x40005ba2c0)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/router.go:144 +0x328
github.com/gofiber/fiber/v2.(*App).handler(0x40002ae900, 0x40004d8000)
	/go/pkg/mod/github.com/gofiber/fiber/v2@v2.47.0/router.go:171 +0xe8
github.com/valyala/fasthttp.(*Server).serveConn(0x4000234600, {0x34d51f0, 0x4000010048})
	/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/server.go:2365 +0x11ac
github.com/valyala/fasthttp.(*workerPool).workerFunc(0x400030dae0, 0x400007c000)
	/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/workerpool.go:224 +0x9c
github.com/valyala/fasthttp.(*workerPool).getCh.func1()
	/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/workerpool.go:196 +0x44
created by github.com/valyala/fasthttp.(*workerPool).getCh
	/go/pkg/mod/github.com/valyala/fasthttp@v1.47.0/workerpool.go:195 +0x2a0
```


This PR aims at fixing this regression.