### PR TITLE
Stricter handling of tag name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,15 @@ jobs:
       # Anything else is invalid.
       - name: Validate ref
         run: |
-          ref=${{ github.event.workflow_run.head_branch }}
-          sha=${{ github.event.workflow_run.head_sha }}
+          ref='${{ github.event.workflow_run.head_branch }}'
+          sha='${{ github.event.workflow_run.head_sha }}'
           case $ref in
             main)
               [ $(git branch --contains=$sha main | wc -l) -eq 1 ] &&
               [ $(git rev-list --count $sha..main) -le 2 ]
               ;;
             v?*)
+              [[ $ref =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
               [ $(git rev-parse refs/tags/$ref) == $sha ] &&
               [ $(git branch --contains=$sha main | wc -l) -eq 1 ]
               ;;
@@ -49,7 +50,7 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          ref=${{ github.event.workflow_run.head_branch }}
+          ref='${{ github.event.workflow_run.head_branch }}'
           case $ref in
             main)
               tags=("main" "edge")


### PR DESCRIPTION
This is to avoid shell injection attacks by committers.