### PR TITLE
Fix integration tests with SQLite backend

### DIFF
--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -37,6 +37,9 @@ func (s *DeleteExperimentTestSuite) SetupTest() {
 }
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {
+	defer func() {
+		assert.Nil(s.T(), s.fixtures.UnloadFixtures())
+	}()
 	experiment, err := s.fixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
 		Tags: []models.ExperimentTag{
@@ -57,9 +60,6 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		ArtifactLocation: "/artifact/location",
 	})
 	assert.Nil(s.T(), err)
-	defer func() {
-		assert.Nil(s.T(), s.fixtures.UnloadFixtures())
-	}()
 
 	experiments, err := s.fixtures.GetTestExperiments(context.Background())
 	length := len(experiments)
@@ -71,9 +71,9 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 	)
 	assert.Nil(s.T(), err)
 
-	remaining_experiments, err := s.fixtures.GetTestExperiments(context.Background())
+	remainingExperiments, err := s.fixtures.GetTestExperiments(context.Background())
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), length-1, len(remaining_experiments))
+	assert.Equal(s.T(), length-1, len(remainingExperiments))
 }
 
 func (s *DeleteExperimentTestSuite) Test_Error() {

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -278,7 +278,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 		},
 		{
 			name:  "DuplicateKeyDifferentValueFails",
-			error: api.NewInternalError("duplicate key"),
+			error: api.NewInternalError("unable to insert params for run"),
 			request: &request.LogBatchRequest{
 				RunID: s.run.ID,
 				Params: []request.ParamPartialRequest{


### PR DESCRIPTION
Integration tests are currently broken when using the SQLite backend. This PR fixes that.