### PR TITLE
Fix "database is locked" issue with SQLite

### DIFF
--- a/pkg/api/mlflow/dao/repositories/experiment.go
+++ b/pkg/api/mlflow/dao/repositories/experiment.go
@@ -88,7 +88,7 @@ func (r ExperimentRepository) GetByName(ctx context.Context, name string) (*mode
 // Update updates existing models.Experiment entity.
 func (r ExperimentRepository) Update(ctx context.Context, experiment *models.Experiment) error {
 	if err := r.db.Transaction(func(tx *gorm.DB) error {
-		if err := r.db.WithContext(ctx).Model(&experiment).Updates(experiment).Error; err != nil {
+		if err := tx.WithContext(ctx).Model(&experiment).Updates(experiment).Error; err != nil {
 			return eris.Wrapf(err, "error updating experiment with id: %d", *experiment.ID)
 		}
 
@@ -99,7 +99,7 @@ func (r ExperimentRepository) Update(ctx context.Context, experiment *models.Exp
 				DeletedTime:    experiment.LastUpdateTime,
 			}
 
-			if err := r.db.WithContext(ctx).Model(&run).Where("experiment_id = ?", experiment.ID).Updates(&run).Error; err != nil {
+			if err := tx.WithContext(ctx).Model(&run).Where("experiment_id = ?", experiment.ID).Updates(&run).Error; err != nil {
 				return eris.Wrapf(err, "error updating existing runs with experiment id: %d", *experiment.ID)
 			}
 		}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -81,7 +81,7 @@ func ConnectDB(
 		}
 		DB.closers = append(DB.closers, s)
 		s.SetMaxIdleConns(1)
-		s.SetMaxOpenConns(4)
+		s.SetMaxOpenConns(1)
 		s.SetConnMaxIdleTime(0)
 		s.SetConnMaxLifetime(0)
 		sourceConn = sqlite.Dialector{


### PR DESCRIPTION
For performance reasons, we used to configure 4 write connections to SQLite, but this can introduce "database is locked" errors when under write load. It's better to be safe and using only 1 write connection is the supported way to write to SQLite as it avoids any concurrency.

Once we start using DuckDB (#85) as our default backend, we'll get much better write performance, especially on concurrent workloads. Users that need better concurrency performance can already use the PostgreSQL backend.