### PR TITLE
Upgrade Go from 1.20 to 1.21

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,20 +1,26 @@
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.18, 1.17, 1-bullseye, 1.18-bullseye, 1.17-bullseye, 1-buster, 1.18-buster, 1.17-buster
-ARG VARIANT=1-bullseye
-FROM mcr.microsoft.com/devcontainers/go:0-${VARIANT}
-
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Go version (use -bookworm, or -bullseye variants on local arm64/Apple Silicon): 1, 1.21, 1.20, 1-bookworm, 1.21-bookworm, 1.20-bookworm, 1-bullseye, 1.21-bullseye, 1.20-bullseye
+ARG VARIANT=1-bookworm
+FROM mcr.microsoft.com/devcontainers/go:1-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends libssl-dev postgresql-client python-is-python3 python3-pip python3-dev python3-venv sqlite3 emacs-nox ripgrep fzf \
-    && pip install pipenv
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    emacs-nox \
+    fzf \
+    libssl-dev \
+    pipenv \
+    postgresql-client \
+    python-is-python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    ripgrep \
+    sqlite3
 
 # [Optional] Uncomment the next lines to use go get to install anything else you need
 USER vscode
-RUN go install github.com/vektra/mockery/v2@v2.30.16 \
- && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3 \
+RUN go install github.com/vektra/mockery/v2@v2.32.4 \
+ && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1 \
  && go install golang.org/x/tools/cmd/goimports@v0.11.0 \
  && go install mvdan.cc/gofumpt@v0.5.0
 USER root
@@ -24,3 +30,7 @@ USER root
 
 # Install xh
 RUN curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | XH_BINDIR=/usr/local/bin sh
+
+# Add docker-compose symlink to Docker Compose v2
+# This is a workaround until https://github.com/devcontainers/features/pull/621 lands
+RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,10 +38,13 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"dockerDashComposeVersion": "v2"
+			"dockerDashComposeVersion": "none"
 		},
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "16"
+		},
 		"ghcr.io/dhoeric/features/k6:1": {},
 		"ghcr.io/christophermacgown/devcontainer-features/minio-client:1": {}
 	},

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,9 +15,7 @@ services:
         # [Choice] Go version 1, 1.18, 1.17
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 1.20-bullseye
-        # Options
-        NODE_VERSION: "16"
+        VARIANT: 1.21-bookworm
     env_file:
       # Ensure that the variables in .env match the same variables in devcontainer.json
       - .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Read build tags
         id: tags
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Download mockery
-        run: go install github.com/vektra/mockery/v2@v2.30.16
+        run: go install github.com/vektra/mockery/v2@v2.32.4
 
       - name: Generate mocks
         run: make mocks-generate
@@ -72,10 +72,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Download mockery
-        run: go install github.com/vektra/mockery/v2@v2.30.16
+        run: go install github.com/vektra/mockery/v2@v2.32.4
 
       - name: Generate mocks
         run: make mocks-generate
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Run Integration Tests
         run: make service-test
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Run ${{ matrix.api }} integration tests
         run: ./tests/integration/python/${{ matrix.api }}/test.sh
@@ -167,7 +167,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 
 # Binaries
+dist/
 fml
 fasttrackml
 *.exe
@@ -27,7 +28,7 @@ mock_*
 go.work
 *.code-workspace
 
-#Python wheels
+# Python wheels
 python/build/
 python/*.egg-info/
 wheelhouse/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build fml binary
-FROM --platform=$BUILDPLATFORM golang:1.20 AS go-build
+FROM --platform=$BUILDPLATFORM golang:1.21 AS go-build
 
 ARG TARGETARCH
 RUN bash -c "\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       MINIO_CONSOLE_ADDRESS: ":9001"
 
   integration-tests:
-    image: golang:1.20
+    image: golang:1.21
     command: make test-go-integration
     volumes:
       - .:/go/src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/G-Research/fasttrackml
 
-go 1.18
+go 1.21
 
 replace (
 	github.com/mattn/go-sqlite3 v1.14.16 => github.com/jgiannuzzi/go-sqlite3 v1.14.17-0.20230327164124-765f25ea5431

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/G-Research/fasttrackml-ui-aim v0.31602.7/go.mod h1:R8eNxWoWxiQ4vXOwkf
 github.com/G-Research/fasttrackml-ui-mlflow v0.20301.1 h1:yDVHbMx0Y8GFZq0D0STnlmIYDIk4phGKCvVIKrlNn00=
 github.com/G-Research/fasttrackml-ui-mlflow v0.20301.1/go.mod h1:0NZjizx6aygBaV8uQ81oCTMVekOFTh6ZDTqTAE6NYdc=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
+github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apache/arrow/go/v12 v12.0.1 h1:JsR2+hzYYjgSUkBSaahpqCetqZMr76djX80fF/DiJbg=
@@ -106,6 +107,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -162,6 +164,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -223,9 +226,11 @@ github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -257,6 +262,7 @@ github.com/rivo/uniseg v0.3.4 h1:3Z3Eu6FGHZWSfNKJTOUiPatWwfc7DzJRU04jFUqJODw=
 github.com/rivo/uniseg v0.3.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rotisserie/eris v0.5.4 h1:Il6IvLdAapsMhvuOahHWiBnl1G++Q0/L5UIkI5mARSk=
 github.com/rotisserie/eris v0.5.4/go.mod h1:Z/kgYTJiJtocxCbFfvRmO+QejApzG6zpyky9G1A4g9s=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -301,6 +307,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -407,6 +414,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -519,6 +527,7 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/gonum v0.11.0 h1:f1IJhK4Km5tBJmaiJXtk/PkL4cdVX6J+tGiM187uT5E=
+gonum.org/v1/gonum v0.11.0/go.mod h1:fSG4YDCxxUZQJ7rKsQrj0gMOg00Il0Z96/qMA4bVQhA=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -610,6 +619,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/pkg/api/mlflow/service/artifact/service_test.go
+++ b/pkg/api/mlflow/service/artifact/service_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -39,7 +38,7 @@ func TestService_ListArtifacts_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByID",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"id",
 	).Return(&models.Run{
 		ID:          "id",
@@ -113,7 +112,7 @@ func TestService_ListArtifacts_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"id",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -139,7 +138,7 @@ func TestService_ListArtifacts_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"id",
 				).Return(&models.Run{
 					ID:          "id",

--- a/pkg/api/mlflow/service/experiment/service_test.go
+++ b/pkg/api/mlflow/service/experiment/service_test.go
@@ -21,10 +21,10 @@ func TestService_CreateExperiment_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+		"GetByName", context.TODO(), "name",
 	).Return(nil, nil)
 	experimentRepository.On(
-		"Create", mock.AnythingOfType("*context.emptyCtx"), mock.Anything,
+		"Create", context.TODO(), mock.Anything,
 	).Return(nil)
 
 	// call service under testing.
@@ -90,7 +90,7 @@ func TestService_CreateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(nil, nil)
 				return NewService(
 					&config.ServiceConfig{},
@@ -108,7 +108,7 @@ func TestService_CreateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(nil, errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -126,7 +126,7 @@ func TestService_CreateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(&models.Experiment{}, nil)
 				return NewService(
 					&config.ServiceConfig{},
@@ -144,10 +144,10 @@ func TestService_CreateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(nil, nil)
 				experimentRepository.On(
-					"Create", mock.AnythingOfType("*context.emptyCtx"), mock.Anything,
+					"Create", context.TODO(), mock.Anything,
 				).Return(errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -165,18 +165,18 @@ func TestService_CreateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(nil, nil)
 				experimentRepository.On(
 					"Create",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.MatchedBy(func(experiment *models.Experiment) bool {
 						experiment.ID = common.GetPointer(int32(1))
 						return true
 					}),
 				).Return(nil)
 				experimentRepository.On(
-					"Update", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*models.Experiment"),
+					"Update", context.TODO(), mock.AnythingOfType("*models.Experiment"),
 				).Return(errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -200,13 +200,13 @@ func TestService_DeleteExperiment_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+		"GetByID", context.TODO(), int32(1),
 	).Return(&models.Experiment{
 		ID: common.GetPointer(int32(1)),
 	}, nil)
 	experimentRepository.On(
 		"Update",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		mock.MatchedBy(func(experiment *models.Experiment) bool {
 			assert.Equal(t, experiment.LifecycleStage, models.LifecycleStageDeleted)
 			assert.NotNil(t, experiment.LastUpdateTime)
@@ -272,7 +272,7 @@ func TestService_DeleteExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(nil, errors.New("experiment not found"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -290,12 +290,12 @@ func TestService_DeleteExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(&models.Experiment{
 					ID: common.GetPointer(int32(1)),
 				}, nil)
 				experimentRepository.On(
-					"Update", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*models.Experiment"),
+					"Update", context.TODO(), mock.AnythingOfType("*models.Experiment"),
 				).Return(errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -318,7 +318,7 @@ func TestService_GetExperiment_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+		"GetByID", context.TODO(), int32(1),
 	).Return(&models.Experiment{
 		ID:   common.GetPointer(int32(1)),
 		Name: "name",
@@ -414,7 +414,7 @@ func TestService_GetExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(nil, errors.New("experiment not found"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -438,7 +438,7 @@ func TestService_GetExperimentByName_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+		"GetByName", context.TODO(), "name",
 	).Return(&models.Experiment{
 		ID:   common.GetPointer(int32(1)),
 		Name: "name",
@@ -518,7 +518,7 @@ func TestService_GetExperimentByName_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(nil, errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -536,7 +536,7 @@ func TestService_GetExperimentByName_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByName", mock.AnythingOfType("*context.emptyCtx"), "name",
+					"GetByName", context.TODO(), "name",
 				).Return(nil, nil)
 				return NewService(
 					&config.ServiceConfig{},
@@ -560,13 +560,13 @@ func TestService_RestoreExperiment_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+		"GetByID", context.TODO(), int32(1),
 	).Return(&models.Experiment{
 		ID: common.GetPointer(int32(1)),
 	}, nil)
 	experimentRepository.On(
 		"Update",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		mock.MatchedBy(func(experiment *models.Experiment) bool {
 			assert.Equal(t, models.LifecycleStageActive, experiment.LifecycleStage)
 			assert.NotNil(t, experiment.LastUpdateTime)
@@ -632,7 +632,7 @@ func TestService_RestoreExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(nil, errors.New("experiment not found"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -650,12 +650,12 @@ func TestService_RestoreExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(&models.Experiment{
 					ID: common.GetPointer(int32(1)),
 				}, nil)
 				experimentRepository.On(
-					"Update", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*models.Experiment"),
+					"Update", context.TODO(), mock.AnythingOfType("*models.Experiment"),
 				).Return(errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -678,7 +678,7 @@ func TestService_SetExperimentTag_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+		"GetByID", context.TODO(), int32(1),
 	).Return(&models.Experiment{
 		ID: common.GetPointer(int32(1)),
 	}, nil)
@@ -686,7 +686,7 @@ func TestService_SetExperimentTag_Ok(t *testing.T) {
 	tagsRepository := repositories.MockTagRepositoryProvider{}
 	tagsRepository.On(
 		"CreateExperimentTag",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		mock.MatchedBy(func(tag *models.ExperimentTag) bool {
 			assert.Equal(t, "key", tag.Key)
 			assert.Equal(t, "value", tag.Value)
@@ -770,7 +770,7 @@ func TestService_SetExperimentTag_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(nil, errors.New("experiment not found"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -789,14 +789,14 @@ func TestService_SetExperimentTag_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(&models.Experiment{
 					ID: common.GetPointer(int32(1)),
 				}, nil)
 				tagRepository := repositories.MockTagRepositoryProvider{}
 				tagRepository.On(
 					"CreateExperimentTag",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.AnythingOfType("*models.ExperimentTag"),
 				).Return(errors.New("database error"))
 
@@ -821,13 +821,13 @@ func TestService_UpdateExperiment_Ok(t *testing.T) {
 	// init repository mocks.
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
-		"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+		"GetByID", context.TODO(), int32(1),
 	).Return(&models.Experiment{
 		ID: common.GetPointer(int32(1)),
 	}, nil)
 	experimentRepository.On(
 		"Update",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		mock.MatchedBy(func(experiment *models.Experiment) bool {
 			assert.Equal(t, "name", experiment.Name)
 			assert.NotNil(t, experiment.LastUpdateTime)
@@ -910,7 +910,7 @@ func TestService_UpdateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(nil, errors.New("experiment not found"))
 				return NewService(
 					&config.ServiceConfig{},
@@ -929,12 +929,12 @@ func TestService_UpdateExperiment_Error(t *testing.T) {
 			service: func() *Service {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
-					"GetByID", mock.AnythingOfType("*context.emptyCtx"), int32(1),
+					"GetByID", context.TODO(), int32(1),
 				).Return(&models.Experiment{
 					ID: common.GetPointer(int32(1)),
 				}, nil)
 				experimentRepository.On(
-					"Update", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*models.Experiment"),
+					"Update", context.TODO(), mock.AnythingOfType("*models.Experiment"),
 				).Return(errors.New("database error"))
 				return NewService(
 					&config.ServiceConfig{},

--- a/pkg/api/mlflow/service/metric/service_test.go
+++ b/pkg/api/mlflow/service/metric/service_test.go
@@ -20,7 +20,7 @@ func TestService_GetMetricHistory_Ok(t *testing.T) {
 	metricRepository := repositories.MockMetricRepositoryProvider{}
 	metricRepository.On(
 		"GetMetricHistoryByRunIDAndKey",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 		"key",
 	).Return([]models.Metric{
@@ -89,7 +89,7 @@ func TestService_GetMetricHistory_Error(t *testing.T) {
 				metricRepository := repositories.MockMetricRepositoryProvider{}
 				metricRepository.On(
 					"GetMetricHistoryByRunIDAndKey",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					"key",
 				).Return(nil, errors.New("database error"))
@@ -112,7 +112,7 @@ func TestService_GetMetricHistoryBulk_Ok(t *testing.T) {
 	metricRepository := repositories.MockMetricRepositoryProvider{}
 	metricRepository.On(
 		"GetMetricHistoryBulk",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		[]string{"1", "2"},
 		"key",
 		10,
@@ -201,7 +201,7 @@ func TestService_GetMetricHistoryBulk_Error(t *testing.T) {
 				metricRepository := repositories.MockMetricRepositoryProvider{}
 				metricRepository.On(
 					"GetMetricHistoryBulk",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					[]string{"1"},
 					"key",
 					10,
@@ -225,7 +225,7 @@ func TestNewService_GetMetricHistories_Ok(t *testing.T) {
 	metricRepository := repositories.MockMetricRepositoryProvider{}
 	metricRepository.On(
 		"GetMetricHistories",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		[]string{"1", "2"},
 		mock.Anything,
 		[]string{"key1", "key2"},
@@ -311,7 +311,7 @@ func TestNewService_GetMetricHistories_Error(t *testing.T) {
 				metricRepository := repositories.MockMetricRepositoryProvider{}
 				metricRepository.On(
 					"GetMetricHistories",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.Anything,
 					[]string{"1"},
 					[]string{"key1", "key2"},

--- a/pkg/api/mlflow/service/run/service_test.go
+++ b/pkg/api/mlflow/service/run/service_test.go
@@ -22,7 +22,7 @@ func TestService_CreateRun_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"Create",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		mock.MatchedBy(func(run *models.Run) bool {
 			assert.NotEmpty(t, run.ID)
 			assert.Equal(t, "name", run.Name)
@@ -45,7 +45,7 @@ func TestService_CreateRun_Ok(t *testing.T) {
 	experimentRepository := repositories.MockExperimentRepositoryProvider{}
 	experimentRepository.On(
 		"GetByID",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		int32(1),
 	).Return(&models.Experiment{
 		ID:               common.GetPointer(int32(1)),
@@ -121,7 +121,7 @@ func TestService_CreateRun_Error(t *testing.T) {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					int32(1),
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -151,13 +151,13 @@ func TestService_CreateRun_Error(t *testing.T) {
 				experimentRepository := repositories.MockExperimentRepositoryProvider{}
 				experimentRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					int32(1),
 				).Return(&models.Experiment{ID: common.GetPointer(int32(1))}, nil)
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"Create",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.MatchedBy(func(run *models.Run) bool {
 						assert.NotEmpty(t, run.ID)
 						assert.Equal(t, "name", run.Name)
@@ -230,7 +230,7 @@ func TestService_UpdateRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -258,12 +258,12 @@ func TestService_RestoreRun_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByID",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 	).Return(&models.Run{ID: "1"}, nil)
 	runRepository.On(
 		"Update",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		&models.Run{
 			ID:             "1",
 			DeletedTime:    sql.NullInt64{Valid: false},
@@ -316,7 +316,7 @@ func TestService_RestoreRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -338,14 +338,14 @@ func TestService_RestoreRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(&models.Run{
 					ID: "1",
 				}, nil)
 				runRepository.On(
 					"Update",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.MatchedBy(func(run *models.Run) bool {
 						assert.Equal(t, "1", run.ID)
 						assert.Equal(t, sql.NullInt64{}, run.DeletedTime)
@@ -378,7 +378,7 @@ func TestService_SetRunTag_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByIDAndLifecycleStage",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 		models.LifecycleStageActive,
 	).Return(
@@ -386,7 +386,7 @@ func TestService_SetRunTag_Ok(t *testing.T) {
 	)
 	runRepository.On(
 		"SetRunTagsBatch",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		&models.Run{ID: "1", LifecycleStage: models.LifecycleStageActive},
 		1,
 		[]models.Tag{{RunID: "1", Key: "key", Value: "value"}},
@@ -416,12 +416,12 @@ func TestService_DeleteRun_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByID",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 	).Return(&models.Run{ID: "1"}, nil)
 	runRepository.On(
 		"Archive",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		&models.Run{ID: "1"},
 	).Return(nil)
 
@@ -470,7 +470,7 @@ func TestService_DeleteRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -492,7 +492,7 @@ func TestService_DeleteRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -514,14 +514,14 @@ func TestService_DeleteRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(&models.Run{
 					ID: "1",
 				}, nil)
 				runRepository.On(
 					"Archive",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.MatchedBy(func(run *models.Run) bool {
 						assert.Equal(t, "1", run.ID)
 						return true
@@ -579,7 +579,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, errors.New("database error"))
@@ -602,7 +602,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, nil)
@@ -626,7 +626,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -636,7 +636,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				tagRepository := repositories.MockTagRepositoryProvider{}
 				tagRepository.On(
 					"GetByRunIDAndKey",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					"key",
 				).Return(nil, errors.New("database error"))
@@ -660,7 +660,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -670,7 +670,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				tagRepository := repositories.MockTagRepositoryProvider{}
 				tagRepository.On(
 					"GetByRunIDAndKey",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					"key",
 				).Return(&models.Tag{
@@ -680,7 +680,7 @@ func TestService_DeleteRunTag_Error(t *testing.T) {
 				}, nil)
 				tagRepository.On(
 					"Delete",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.MatchedBy(func(tag *models.Tag) bool {
 						assert.Equal(t, "1", tag.RunID)
 						assert.Equal(t, "key", tag.Key)
@@ -713,7 +713,7 @@ func TestService_GetRun_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByID",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 	).Return(&models.Run{
 		ID:             "1",
@@ -831,7 +831,7 @@ func TestService_GetRun_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -859,7 +859,7 @@ func TestService_LogBatch_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByIDAndLifecycleStage",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 		models.LifecycleStageActive,
 	).Return(&models.Run{
@@ -868,7 +868,7 @@ func TestService_LogBatch_Ok(t *testing.T) {
 	}, nil)
 	runRepository.On(
 		"SetRunTagsBatch",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		&models.Run{ID: "1", LifecycleStage: models.LifecycleStageActive},
 		100,
 		mock.MatchedBy(func(tags []models.Tag) bool {
@@ -881,7 +881,7 @@ func TestService_LogBatch_Ok(t *testing.T) {
 	paramRepository := repositories.MockParamRepositoryProvider{}
 	paramRepository.On(
 		"CreateBatch",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		100,
 		mock.MatchedBy(func(params []models.Param) bool {
 			assert.Equal(t, "1", params[0].RunID)
@@ -893,7 +893,7 @@ func TestService_LogBatch_Ok(t *testing.T) {
 	metricRepository := repositories.MockMetricRepositoryProvider{}
 	metricRepository.On(
 		"CreateBatch",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		&models.Run{ID: "1", LifecycleStage: models.LifecycleStageActive},
 		100,
 		mock.MatchedBy(func(metrics []models.Metric) bool {
@@ -973,7 +973,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, errors.New("database error"))
@@ -996,7 +996,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, nil)
@@ -1019,7 +1019,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, nil)
@@ -1048,7 +1048,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -1079,7 +1079,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -1088,7 +1088,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				paramRepository := repositories.MockParamRepositoryProvider{}
 				paramRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					100,
 					[]models.Param{
 						{
@@ -1131,7 +1131,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -1141,7 +1141,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				paramRepository := repositories.MockParamRepositoryProvider{}
 				paramRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					100,
 					[]models.Param{
 						{
@@ -1154,7 +1154,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				metricRepository := repositories.MockMetricRepositoryProvider{}
 				metricRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					&models.Run{
 						ID:             "1",
 						LifecycleStage: models.LifecycleStageActive,
@@ -1209,7 +1209,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -1218,7 +1218,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				}, nil)
 				runRepository.On(
 					"SetRunTagsBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					&models.Run{
 						ID:             "1",
 						LifecycleStage: models.LifecycleStageActive,
@@ -1235,7 +1235,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				paramRepository := repositories.MockParamRepositoryProvider{}
 				paramRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					100,
 					[]models.Param{
 						{
@@ -1248,7 +1248,7 @@ func TestService_LogBatch_Error(t *testing.T) {
 				metricRepository := repositories.MockMetricRepositoryProvider{}
 				metricRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					&models.Run{
 						ID:             "1",
 						LifecycleStage: models.LifecycleStageActive,
@@ -1289,7 +1289,7 @@ func TestService_LogMetric_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByID",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 	).Return(&models.Run{
 		ID:             "1",
@@ -1298,7 +1298,7 @@ func TestService_LogMetric_Ok(t *testing.T) {
 	metricRepository := repositories.MockMetricRepositoryProvider{}
 	metricRepository.On(
 		"CreateBatch",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		&models.Run{ID: "1", LifecycleStage: models.LifecycleStageActive},
 		1,
 		mock.MatchedBy(func(metrics []models.Metric) bool {
@@ -1398,7 +1398,7 @@ func TestService_LogMetric_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(nil, errors.New("database error"))
 				return NewService(
@@ -1423,7 +1423,7 @@ func TestService_LogMetric_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(&models.Run{
 					ID: "1",
@@ -1451,7 +1451,7 @@ func TestService_LogMetric_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByID",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 				).Return(&models.Run{
 					ID: "1",
@@ -1459,7 +1459,7 @@ func TestService_LogMetric_Error(t *testing.T) {
 				metricRepository := repositories.MockMetricRepositoryProvider{}
 				metricRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					mock.MatchedBy(func(run *models.Run) bool {
 						assert.Equal(t, "1", run.ID)
 						return true
@@ -1500,7 +1500,7 @@ func TestService_LogParam_Ok(t *testing.T) {
 	runRepository := repositories.MockRunRepositoryProvider{}
 	runRepository.On(
 		"GetByIDAndLifecycleStage",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		"1",
 		models.LifecycleStageActive,
 	).Return(&models.Run{
@@ -1510,7 +1510,7 @@ func TestService_LogParam_Ok(t *testing.T) {
 	paramRepository := repositories.MockParamRepositoryProvider{}
 	paramRepository.On(
 		"CreateBatch",
-		mock.AnythingOfType("*context.emptyCtx"),
+		context.TODO(),
 		1,
 		mock.MatchedBy(func(params []models.Param) bool {
 			assert.Equal(t, "1", params[0].RunID)
@@ -1587,7 +1587,7 @@ func TestService_LogParam_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, errors.New("database error"))
@@ -1612,7 +1612,7 @@ func TestService_LogParam_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(nil, nil)
@@ -1637,7 +1637,7 @@ func TestService_LogParam_Error(t *testing.T) {
 				runRepository := repositories.MockRunRepositoryProvider{}
 				runRepository.On(
 					"GetByIDAndLifecycleStage",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					"1",
 					models.LifecycleStageActive,
 				).Return(&models.Run{
@@ -1647,7 +1647,7 @@ func TestService_LogParam_Error(t *testing.T) {
 				paramRepository := repositories.MockParamRepositoryProvider{}
 				paramRepository.On(
 					"CreateBatch",
-					mock.AnythingOfType("*context.emptyCtx"),
+					context.TODO(),
 					1,
 					mock.MatchedBy(func(params []models.Param) bool {
 						assert.Equal(t, 1, len(params))


### PR DESCRIPTION
- Upgrade devcontainer to Debian bookworm
- Upgrade mockery from 2.30.16 to 2.32.4
- Upgrade golangci-lint from 1.53.3 to 1.54.1
- Use context directly in unit tests as mocking depends on Go internals that changed in Go 1.21