### PR TITLE
Add database migrations support for MLFlow 2.3.0 to 2.6.0

### DIFF
--- a/pkg/database/migrate.go
+++ b/pkg/database/migrate.go
@@ -4,10 +4,17 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+var supportedAlembicVersions = []string{
+	"97727af70f4d",
+	"3500859a5d39",
+	"7f2a7d5fae7d",
+}
 
 func checkAndMigrate(migrate bool, dbProvider DBProvider) error {
 	db := dbProvider.GormDB()
@@ -21,7 +28,7 @@ func checkAndMigrate(migrate bool, dbProvider DBProvider) error {
 		tx.First(&schemaVersion)
 	}
 
-	if alembicVersion.Version != "97727af70f4d" || schemaVersion.Version != "5d042539be4f" {
+	if !slices.Contains(supportedAlembicVersions, alembicVersion.Version) || schemaVersion.Version != "5d042539be4f" {
 		if !migrate && alembicVersion.Version != "" {
 			return fmt.Errorf("unsupported database schema versions alembic %s, FastTrackML %s", alembicVersion.Version, schemaVersion.Version)
 		}
@@ -106,7 +113,7 @@ func checkAndMigrate(migrate bool, dbProvider DBProvider) error {
 			}
 			fallthrough
 
-		case "97727af70f4d":
+		case "97727af70f4d", "3500859a5d39", "7f2a7d5fae7d":
 			switch schemaVersion.Version {
 			case "":
 				log.Info("Migrating database to FastTrackML schema ac0b8b7c0014")


### PR DESCRIPTION
MLFlow 2.3.0 introduced a new alembic schema version `3500859a5d39` which only adds tables used by the model versioning server, which we don't implement. We however need to know about this schema version in order to be compatible with MLFlow databases used with this version of MLFlow.

MLFlow 2.4.0 introduced `7f2a7d5fae7d` which only adds tables used by the new dataset tracking feature, which we don't implement either. This schema version is used up to at least MLFlow 2.6.0 (at the time of writing of this PR).