### PR TITLE
Improve help and version outputs

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -16,12 +18,11 @@ const (
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "fml",
-	Short: "A fast experiment tracking server compatible with MLFlow",
-	Long: `FastTrackML is a rewrite of the MLFlow tracking server with a focus on scalability.
+	Use:   filepath.Base(os.Args[0]),
+	Short: "Experiment tracking server focused on speed and scalability",
+	Long: `FastTrackML is an experiment tracking server focused on speed and scalability.
 It aims at being 100% compatible with the MLFlow client library and should be a
-drop-in replacement. It can even use existing SQLite/SQLCipher/PostgreSQL
-databases created by MLFlow 1.21+.`,
+drop-in replacement.`,
 	Version:           version.Version,
 	PersistentPreRunE: initCmd,
 	SilenceUsage:      true,
@@ -29,7 +30,9 @@ databases created by MLFlow 1.21+.`,
 }
 
 func initCmd(cmd *cobra.Command, args []string) error {
-	viper.BindPFlags(cmd.Flags())
+	if err := viper.BindPFlags(cmd.Flags()); err != nil {
+		return err
+	}
 
 	level, err := log.ParseLevel(viper.GetString("log-level"))
 	if err != nil {
@@ -44,6 +47,7 @@ func initCmd(cmd *cobra.Command, args []string) error {
 
 func init() {
 	RootCmd.PersistentFlags().StringP("log-level", "l", "info", "Log level")
+	RootCmd.SetVersionTemplate("FastTrackML version {{.Version}}\n")
 
 	viper.SetEnvPrefix(envPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))


### PR DESCRIPTION
* Use actual binary name in help output
* Improved description in help output
* Use full project name in version output
* Fix linting issue in `pkg/cmd/root.go`

Before:
```
$ ./fml
FastTrackML is a rewrite of the MLFlow tracking server with a focus on scalability.
It aims at being 100% compatible with the MLFlow client library and should be a
drop-in replacement. It can even use existing SQLite/SQLCipher/PostgreSQL
databases created by MLFlow 1.21+.

Usage:
  fml [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  import      Copies an input database to an output database
  server      Starts the tracking server

Flags:
  -h, --help               help for fml
  -l, --log-level string   Log level (default "info")
  -v, --version            version for fml

Use "fml [command] --help" for more information about a command.
$ ./fml --version
fml version 0.3.0-16-g4ff756a6
```

After:
```
$ ./fml
FastTrackML is an experiment tracking server focused on speed and scalability.
It aims at being 100% compatible with the MLFlow client library and should be a
drop-in replacement.

Usage:
  fml [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  import      Copies an input database to an output database
  server      Starts the tracking server

Flags:
  -h, --help               help for fml
  -l, --log-level string   Log level (default "info")
  -v, --version            version for fml

Use "fml [command] --help" for more information about a command.
$ ./fml --version
FastTrackML version 0.3.0-17-gf4652c30