### PR TITLE
Fix Postgres connection pool regression

### DIFF
--- a/pkg/database/postgres_db_instance.go
+++ b/pkg/database/postgres_db_instance.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"net/url"
 	"time"
 
@@ -48,11 +47,11 @@ func NewPostgresDBInstance(
 	})
 	if err != nil {
 		db.Close()
-		return nil, fmt.Errorf("failed to connect to database: %w", err)
+		return nil, eris.Wrap(err, "failed to connect to database")
 	}
 	db.DB = gormDB
 
-	sqlDB, err := db.DB.DB()
+	sqlDB, err := gormDB.DB()
 	if err != nil {
 		return nil, eris.Wrap(err, "failed to get underlying database connection pool")
 	}

--- a/pkg/database/sqlite_db_instance.go
+++ b/pkg/database/sqlite_db_instance.go
@@ -3,7 +3,6 @@ package database
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/url"
 	"os"
 	"regexp"
@@ -59,7 +58,7 @@ func NewSqliteDBInstance(
 		}
 		log.Infof("Removing database file %s", file)
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("failed to remove database file: %w", err)
+			return nil, eris.Wrap(err, "failed to remove database file")
 		}
 	}
 
@@ -88,7 +87,7 @@ func NewSqliteDBInstance(
 
 	s, err := sql.Open(SQLiteCustomDriverName, strings.Replace(dsnURL.String(), "sqlite://", "file:", 1))
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to database: %w", err)
+		return nil, eris.Wrap(err, "failed to connect to database")
 	}
 	db.closers = append(db.closers, s)
 	s.SetMaxIdleConns(1)
@@ -104,7 +103,7 @@ func NewSqliteDBInstance(
 	r, err := sql.Open(SQLiteCustomDriverName, strings.Replace(dsnURL.String(), "sqlite://", "file:", 1))
 	if err != nil {
 		db.Close()
-		return nil, fmt.Errorf("failed to connect to database: %w", err)
+		return nil, eris.Wrap(err, "failed to connect to database")
 	}
 	db.closers = append(db.closers, r)
 	replicaConn = sqlite.Dialector{
@@ -127,7 +126,7 @@ func NewSqliteDBInstance(
 	})
 	if err != nil {
 		db.Close()
-		return nil, fmt.Errorf("failed to connect to database: %w", err)
+		return nil, eris.Wrap(err, "failed to connect to database")
 	}
 
 	db.Use(


### PR DESCRIPTION
#250 introduced a regression by removing the connection pool settings from our Postgres backend. This PR fixes it, and also wraps all the database creation errors with `eris.Wrap`.