### PR TITLE
Fix issue with searching for metric names via regex

### DIFF
--- a/pkg/api/aim/query/clause.go
+++ b/pkg/api/aim/query/clause.go
@@ -16,8 +16,10 @@ func (regexp Regexp) Build(builder clause.Builder) {
 	builder.WriteQuoted(regexp.Column)
 	switch regexp.Dialector {
 	case postgres.Dialector{}.Name():
+		// #nosec G104
 		builder.WriteString(" ~ ")
 	default:
+		// #nosec G104
 		builder.WriteString(" REGEXP ")
 	}
 	builder.AddVar(builder, regexp.Value)
@@ -28,8 +30,10 @@ func (regexp Regexp) NegationBuild(builder clause.Builder) {
 	builder.WriteQuoted(regexp.Column)
 	switch regexp.Dialector {
 	case postgres.Dialector{}.Name():
+		// #nosec G104
 		builder.WriteString(" !~ ")
 	default:
+		// #nosec G104
 		builder.WriteString(" NOT REGEXP ")
 	}
 	builder.AddVar(builder, regexp.Value)

--- a/pkg/api/aim/query/clause.go
+++ b/pkg/api/aim/query/clause.go
@@ -18,7 +18,7 @@ func (regexp Regexp) Build(builder clause.Builder) {
 	case postgres.Dialector{}.Name():
 		builder.WriteString(" ~ ")
 	default:
-		builder.WriteString(" regexp ")
+		builder.WriteString(" REGEXP ")
 	}
 	builder.AddVar(builder, regexp.Value)
 }
@@ -30,7 +30,7 @@ func (regexp Regexp) NegationBuild(builder clause.Builder) {
 	case postgres.Dialector{}.Name():
 		builder.WriteString(" !~ ")
 	default:
-		builder.WriteString(" NOT regexp ")
+		builder.WriteString(" NOT REGEXP ")
 	}
 	builder.AddVar(builder, regexp.Value)
 }

--- a/pkg/api/aim/query/clause.go
+++ b/pkg/api/aim/query/clause.go
@@ -1,8 +1,6 @@
 package query
 
 import (
-	"fmt"
-
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm/clause"
 )
@@ -22,7 +20,7 @@ func (regexp Regexp) Build(builder clause.Builder) {
 	default:
 		builder.WriteString(" regexp ")
 	}
-	builder.AddVar(builder, fmt.Sprintf("%s", regexp.Value))
+	builder.AddVar(builder, regexp.Value)
 }
 
 // NegationBuild builds negative statement.

--- a/pkg/api/aim/query/query_test.go
+++ b/pkg/api/aim/query/query_test.go
@@ -193,28 +193,28 @@ func (s *QueryTestSuite) TestSqliteDialector_Ok() {
 			name:  "TestRunNameWithRegexpMatchFunction",
 			query: `(re.match('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE (IFNULL("runs"."name", '') REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"^run", models.LifecycleStageDeleted},
 		},
 		{
 			name:  "TestRunNameWithRegexpSearchFunction",
 			query: `(re.search('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE (IFNULL("runs"."name", '') REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"run", models.LifecycleStageDeleted},
 		},
 		{
 			name:  "TestRunNameWithNegatedRegexpMatchFunction",
 			query: `not (re.match('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" NOT REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE (IFNULL("runs"."name", '') NOT REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"^run", models.LifecycleStageDeleted},
 		},
 		{
 			name:  "TestRunNameWithNegatedRegexpSearchFunction",
 			query: `not (re.search('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" NOT REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE (IFNULL("runs"."name", '') NOT REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"run", models.LifecycleStageDeleted},
 		},
 		{

--- a/pkg/api/aim/query/query_test.go
+++ b/pkg/api/aim/query/query_test.go
@@ -193,28 +193,28 @@ func (s *QueryTestSuite) TestSqliteDialector_Ok() {
 			name:  "TestRunNameWithRegexpMatchFunction",
 			query: `(re.match('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" regexp $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE ("runs"."name" REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"^run", models.LifecycleStageDeleted},
 		},
 		{
 			name:  "TestRunNameWithRegexpSearchFunction",
 			query: `(re.search('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" regexp $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE ("runs"."name" REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"run", models.LifecycleStageDeleted},
 		},
 		{
 			name:  "TestRunNameWithNegatedRegexpMatchFunction",
 			query: `not (re.match('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" NOT regexp $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE ("runs"."name" NOT REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"^run", models.LifecycleStageDeleted},
 		},
 		{
 			name:  "TestRunNameWithNegatedRegexpSearchFunction",
 			query: `not (re.search('run', run.name))`,
 			expectedSQL: `SELECT "run_uuid" FROM "runs" ` +
-				`WHERE ("runs"."name" NOT regexp $1 AND "runs"."lifecycle_stage" <> $2)`,
+				`WHERE ("runs"."name" NOT REGEXP $1 AND "runs"."lifecycle_stage" <> $2)`,
 			expectedVars: []interface{}{"run", models.LifecycleStageDeleted},
 		},
 		{


### PR DESCRIPTION
Fixes #414.

There are also a few minor changes:
- an unnecessary call to `fmt.Sprintf` was removed
- SQL expressions have been made uppercase for consistency
- a few linting issues have been "fixed" by ignoring them as we stick to the Gorm conventions

I didn't add test cases to the integration tests to avoid merge conflicts with `features/namespaces`, but we should definitely cover this — see https://github.com/G-Research/fasttrackml/issues/414#issuecomment-1744744382 for how to reproduce.