### PR TITLE
Add dynamic id to website announcement bar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -147,7 +147,7 @@ module.exports = async function configCreatorAsync() {
                 },
                 announcementBar: {
                     // https://docusaurus.io/docs/api/themes/configuration#announcement-bar
-                    id: 'announcement-bar',
+                    id: `announcement-bar-${releaseVersion}`,
                     content: `FastTrackML ${releaseVersion} has been <a href="${releaseUrl}" target="_blank">released</a>!`,
                     isCloseable: true,
                 },


### PR DESCRIPTION
This PR changes the announcement bar `id` to be dynamic, so than when the bar has been dismissed for a past release, it appears again when there is a new release.
