### PR TITLE
Change CI release logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,3 +342,14 @@ jobs:
             skopeo copy --all oci-archive:fasttrackml-oci.tar:$tag docker://ghcr.io/${{ steps.repo.outputs.name }}:$tag
             echo "::endgroup::"
           done
+
+  release:
+    name: Release
+    needs: all-required-checks-done
+    if: ${{ !github.event.repository.fork && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    secrets: inherit
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -1,0 +1,96 @@
+name: Create release branch or tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: "What to create (branch or tag)"
+        required: true
+        type: choice
+        options:
+          - "branch"
+          - "tag"
+      version:
+        description: "Version - major and minor for a branch (e.g. 0.3), semver for a tag (e.g. 0.3.1 or 0.3.1-rc.1)"
+        required: true
+
+jobs:
+  create-release:
+    name: Create release branch from main
+    if: github.event.inputs.type == 'branch'
+    environment: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check version
+        id: version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+            const version = context.payload.inputs.version;
+            const match = version.match(semver);
+            if (match === null) {
+              core.setFailed('Invalid version format. Expected "MAJOR.MINOR".');
+            } else {
+              core.setOutput('branch', `release/${version}`);
+            }
+
+      - name: Generate an app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Push
+        run: |
+          branch=${{ steps.version.outputs.branch }}
+          git checkout -b $branch
+          git push origin $branch
+
+  create-tag:
+    name: Create release tag from release branch
+    if: github.event.inputs.type == 'tag'
+    environment: create-release
+    runs-on: ubuntu-latest
+    steps:
+      # Regex comes from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+      - name: Check version
+        id: version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+            const version = context.payload.inputs.version;
+            const match = version.match(semver);
+            if (match === null) {
+              core.setFailed('Invalid version format. Expected semver compliant version.');
+            } else {
+              core.setOutput('tag', `v${version}`);
+              core.setOutput('branch', `release/${match[1]}.${match[2]}`);
+            }
+
+      - name: Generate an app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.branch }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Push
+        run: |
+          tag=${{ steps.version.outputs.tag }}
+          git tag $tag
+          git push origin $tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,96 +1,55 @@
 name: Release
 
 on:
-  workflow_run:
-    types: [completed]
-    workflows: [CI]
-    branches:
-      - main
-      - v*
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate ref
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && !github.event.repository.fork
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # The given ref should belong to the main branch.
-      # If it's main, it shouldn't be more than 2 commits away (in case another push happened in the meantime).
-      # If it starts with 'v', it should be a tag and belong to the main branch.
-      # Anything else is invalid.
-      - name: Validate ref
-        run: |
-          ref='${{ github.event.workflow_run.head_branch }}'
-          sha='${{ github.event.workflow_run.head_sha }}'
-          case $ref in
-            main)
-              [ $(git branch --contains=$sha main | wc -l) -eq 1 ] &&
-              [ $(git rev-list --count $sha..main) -le 2 ]
-              ;;
-            v?*)
-              [[ $ref =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
-              [ $(git tag --points-at $sha | grep -E "^$ref\$" | wc -l) -eq 1 ] &&
-              [ $(git branch --contains=$sha main | wc -l) -eq 1 ]
-              ;;
-            *)
-              false
-              ;;
-          esac
-          if [ $? -ne 0 ]; then
-            echo "::error ::Invalid ref $ref $sha"
-            exit 1
-          fi
-
   pypi-publish:
     name: upload release to PyPI
-    needs: validate
-    if: github.event.workflow_run.head_branch != 'main'
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
     steps:
       - name: Download artifact
-        run: gh run download ${{ github.event.workflow_run.id }} --repo ${{ github.event.workflow_run.repository.full_name }} --name fasttrackml-wheels --dir wheelhouse
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: actions/download-artifact@v3
+        with:
+          name: fasttrackml-wheels
+          path: wheelhouse
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: wheelhouse/
+          packages-dir: wheelhouse
 
   github-release:
     name: Publish GitHub release
-    needs: validate
-    if: github.event.workflow_run.head_branch != 'main'
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Download artifact
-        run: gh run download ${{ github.event.workflow_run.id }} --repo ${{ github.event.workflow_run.repository.full_name }} --name fasttrackml-archives --dir dist
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: actions/download-artifact@v3
+        with:
+          name: fasttrackml-archives
+          path: dist
 
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           files: dist/*
-          tag_name: ${{ github.event.workflow_run.head_branch }}
+          prerelease: ${{ contains(github.ref, '-') }}
 
   update-website:
     name: Update website
     needs: github-release
+    if: ${{ !contains(github.ref, '-') }}
     permissions:
       contents: read
       pages: write
@@ -99,35 +58,43 @@ jobs:
 
   docker-release:
     name: Publish container image to DockerHub
-    needs: validate
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release
     steps:
+      # We need to checkout the repo in order to determine the latest tag.
       - name: Checkout
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # The main branch is tagged as "main" and "edge".
+      # Tags are named after the version, e.g. "v0.1.0" -> "0.1.0".
+      # The latest non-prerelease version is also tagged as "latest".
+      # This is achieved by sorting the tags by version number, then filtering
+      # out prereleases and taking the last tag.
       - name: Compute tags
         id: tags
         run: |
-          ref='${{ github.event.workflow_run.head_branch }}'
+          ref='${{ github.ref }}'
           case $ref in
-            main)
+            refs/heads/main)
               tags=("main" "edge")
               ;;
-            v*)
-              tags=("${ref#v}")
-              if [ $(git describe --tags --abbrev=0) == $ref ]; then
+            refs/tags/v*)
+              tags=("${ref#refs/tags/v}")
+              if [ "$(git -c 'versionsort.suffix=-' for-each-ref --sort=version:refname --format='%(refname)' 'refs/tags/v*' | grep -v -- - | tail -n1)" == "$ref" ]; then
                 tags+=("latest")
               fi
           esac
+          echo "ref=${ref#refs/*/}" >> $GITHUB_OUTPUT
           echo "tags=${tags[@]}" >> $GITHUB_OUTPUT
 
       - name: Download artifact
-        run: gh run download ${{ github.event.workflow_run.id }} --name fasttrackml-oci-image
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: actions/download-artifact@v3
+        with:
+          name: fasttrackml-oci-image
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -140,6 +107,6 @@ jobs:
           for tag in ${{ steps.tags.outputs.tags }}
           do
             echo "::group::Pushing image to ${{ vars.DOCKER_REPO }}:$tag"
-            skopeo copy --all oci-archive:fasttrackml-oci.tar:${{ github.event.workflow_run.head_branch }} docker://${{ vars.DOCKER_REPO }}:$tag
+            skopeo copy --all oci-archive:fasttrackml-oci.tar:${{ steps.tags.outputs.ref }} docker://${{ vars.DOCKER_REPO }}:$tag
             echo "::endgroup::"
           done

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -1,0 +1,154 @@
+# Maintainer guide
+
+## Release workflow
+
+* All development goes into the `main` branch via pull requests that need to be
+  approved and checks that need to pass.
+* When we want to cut a new major or minor release, we can create a new release
+  branch named `release/MAJOR.MINOR` (e.g. `release/0.4`) by manually running
+  the `Create release branch or tag` workflow.
+* We can then run the workflow again to create a tag, specifying the complete
+  semantic version (e.g. `0.4.0` or `0.4.0-beta.1`).
+* Development continues on the `main` branch.
+* Fixes can be backported to the release branch via pull requests that need to
+  be approved and checks that need to pass.
+* A new patch release can then be made by calling the
+  `Create release branch or tag` workflow again.
+
+## How is it enforced
+
+* A GitHub app needs to exist and be installed on the repo with the
+  `contents:write` permissions. Its ID and private key need to be stored as
+  secrets under the `create-release` environment. This environment needs to be
+  limited to the `main` branch only.
+* An environment named `release` needs to exist and be limited to the `main`
+  branch and the `v*` tags only. It needs to contain the Docker Hub credentials
+  as secrets and be registered on PyPI as a trusted provider for our Python
+  package.
+* The following rulesets must exist on the repo to enforce this workflow and
+  guarantee that a single maintainer cannot make changes to the codebase that
+  have not been reviewed by their peers. They replace any other branch
+  protection rules that may have existed before.
+  ```json
+  [
+    {
+      "name": "Allow bot to create release branches",
+      "target": "branch",
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "refs/heads/release/**/*"
+          ]
+        }
+      },
+      "rules": [
+        {
+          "type": "creation"
+        }
+      ],
+      "bypass_actors": [
+        {
+          "actor_id": 0,
+          "actor_type": "Integration",
+          "bypass_mode": "always"
+        }
+      ]
+    },
+    {
+      "name": "Allow bot to create tags",
+      "target": "tag",
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "~ALL"
+          ]
+        }
+      },
+      "rules": [
+        {
+          "type": "creation"
+        }
+      ],
+      "bypass_actors": [
+        {
+          "actor_id": 0,
+          "actor_type": "Integration",
+          "bypass_mode": "always"
+        }
+      ]
+    },
+    {
+      "name": "Protect all tags",
+      "target": "tag",
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "~ALL"
+          ]
+        }
+      },
+      "rules": [
+        {
+          "type": "deletion"
+        },
+        {
+          "type": "non_fast_forward"
+        },
+        {
+          "type": "update"
+        }
+      ],
+      "bypass_actors": []
+    },
+    {
+      "name": "Protect main and release branches",
+      "target": "branch",
+      "conditions": {
+        "ref_name": {
+          "exclude": [],
+          "include": [
+            "refs/heads/main",
+            "refs/heads/release/**/*"
+          ]
+        }
+      },
+      "rules": [
+        {
+          "type": "deletion"
+        },
+        {
+          "type": "non_fast_forward"
+        },
+        {
+          "type": "required_linear_history"
+        },
+        {
+          "type": "pull_request",
+          "parameters": {
+            "require_code_owner_review": false,
+            "require_last_push_approval": true,
+            "dismiss_stale_reviews_on_push": true,
+            "required_approving_review_count": 1,
+            "required_review_thread_resolution": false
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "required_status_checks": [
+              {
+                "context": "All required checks succeeded",
+                "integration_id": 0
+              }
+            ],
+            "strict_required_status_checks_policy": true
+          }
+        }
+      ],
+      "bypass_actors": []
+    }
+  ]
+  ```


### PR DESCRIPTION
This PR changes the CI release logic in the following way:
* add a workflow `create.yml` to create release branches and tags in a controlled manner, using a GitHub app that will have exceptions in the rulesets
* change the `release.yml` workflow to be directly called by the main CI workflow
* change `release.yml` to not validate the ref anymore, but instead rely on rulesets and environments
* add support for prereleases
* document workflow in `docs/maintainer.md`

---

The following tasks need to be completed before merging this PR (more information can be found in the documentation):
- [x] create and install a new GitHub app
- [x] add its credentials to a new `create-release` environment that can only be accessed by the `main` branch
- [x] add the required rulesets — this _**has**_ to be done before the next step!
- [x] change the `release` environment to also allow `v*` tag patterns (and keep the existing `main` branch)

---

Examples on a repo that has been setup as described and as "upstream" (so _not_ a fork, but in this case a copy):
> [!NOTE]
> Many of these links may require to be reloaded before they display the actual log line I want to show — this seems to be a GitHub bug at the time of writing
- [Run on `main`](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6516940465): notice in particular that the `main` and `edge` tags are [published on Docker Hub](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6516940465/job/17701004503#step:6:1)
- [Run to create a `0.3` release branch](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6516981234): notice in particular that the app/bot is able to [bypass the branch creation rule](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6516981234/job/17701043283#step:5:8) to create the branch
  <img width="328" alt="image" src="https://github.com/G-Research/fasttrackml/assets/3692455/5fafa68b-f645-48c7-a372-3b9244981d29">
- [Run on the `0.3` release branch](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6516983137): notice that the [release workflow is skipped](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6516983137/job/17701141666)
- [Run to create a `0.3.5-beta.1` tag](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517063046): the app/bot can [bypass the tag creation rule](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517063046/job/17701193768#step:5:7)
  <img width="327" alt="image" src="https://github.com/G-Research/fasttrackml/assets/3692455/242e539a-34db-43ee-90ec-24618a05040f">
- [Run on the `0.3.5-beta.1` tag](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517064457): notice that the `latest` tag does _not_ get [published on Docker Hub](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517064457/job/17701262634#step:6:1), that the GitHub release is [created as a prerelease](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517064457/job/17701262705#step:3:5), and that [the website does _not_ get updated](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517064457/job/17701264496) for the announcement — PyPI publishing does not work intentionally because it would have required changing the package name
- [Run to create a `0.3.5` tag](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517114951): the app/bot can [bypass the tag creation rule](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517114951/job/17701280597#step:5:7)
- [Run on the `0.3.5` tag](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517116112): notice that the `latest` tag is [published on Docker Hub](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517116112/job/17701345268#step:6:1), that the GitHub release is [created as a normal release](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517116112/job/17701345222#step:3:5), and that the [website gets updated](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517116112/job/17701348448) for the announcement — PyPI publishing does not work intentionally because it would have required changing the package name
- [Run to create a wrong `0.04` release branch](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517125784): notice the [error message](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517125784/job/17701302321#step:2:19)
- [Run to create a wrong `0.3.5beta.1` tag](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517127079): notice the [error message](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517127079/job/17701304591#step:2:20)
- [Run to create a `0.4.5` tag when the `0.4` branch does not exist](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517128214): notice the [error message](https://github.com/jgiannuzzi-org/fasttrackml/actions/runs/6517128214/job/17701306969#step:4:59)