### PR TITLE
Do not run "Check required jobs" on forks

### DIFF
--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   required-jobs:
     name: Check required jobs
+    if: ${{ !github.event.repository.fork }}
     environment: create-check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#458 introduced the use of a GitHub environment and a GitHub app to implement the required checks. On repo forks, these will most likely not exist, and the need for any kind of required checks is probably close to zero.

This PR is thus disabling the required checks creations on forks.