### PR TITLE
Check module files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,17 @@ jobs:
             exit 1
           fi
 
+      - name: Check module files
+        run: |
+          go mod tidy
+          modified=$(git ls-files --modified -- go.{mod,sum})
+          if [ -n "$modified" ]; then
+            for file in $modified; do
+              echo "::error file=$file::$file is not up to date (hint: run \"go mod tidy\" to fix this)"
+            done
+            exit 1
+          fi
+
       - name: Check mocks
         run: |
           make mocks-generate


### PR DESCRIPTION
This will help us remember running `go mod tidy` before merging anything.

Example run with failure here: https://github.com/jgiannuzzi/fasttrackml/actions/runs/6560857545
<img width="504" alt="image" src="https://github.com/G-Research/fasttrackml/assets/3692455/eb45a2f5-0cf0-44ef-aee0-e0ce432f1329">
