### PR TITLE
[release/0.3] Stop gracefully on SIGTERM

### DIFF
--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -102,7 +103,7 @@ func serverCmd(cmd *cobra.Command, args []string) error {
 	isRunning := make(chan struct{})
 	go func() {
 		sigint := make(chan os.Signal, 1)
-		signal.Notify(sigint, os.Interrupt)
+		signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
 		<-sigint
 
 		log.Infof("Shutting down")


### PR DESCRIPTION
Backport of #476 to `release/0.3`. Fixes #445.