### PR TITLE
Fix wrong Y axis scale in Aim UI when metric has infinity values

### DIFF
--- a/pkg/api/aim/runs.go
+++ b/pkg/api/aim/runs.go
@@ -1140,6 +1140,12 @@ func DeleteBatch(c *fiber.Ctx) error {
 func toNumpy(values []float64) fiber.Map {
 	buf := bytes.NewBuffer(make([]byte, 0, len(values)*8))
 	for _, v := range values {
+		switch v {
+		case math.MaxFloat64:
+			v = math.Inf(1)
+		case -math.MaxFloat64:
+			v = math.Inf(-1)
+		}
 		//nolint:gosec,errcheck
 		binary.Write(buf, binary.LittleEndian, v)
 	}


### PR DESCRIPTION
The Aim UI knows how to deal with such values but we were not mapping them correctly in the encoded result, as MLFlow's database storage uses MaxFloat64 instead of infinity. This PR adds a mapping back from MaxFloat64 to proper infinity.

Fixes #489 