### PR TITLE
Restore functionality to update the website when a release is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,7 @@ jobs:
     needs: all-required-checks-done
     if: ${{ !github.event.repository.fork && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
     permissions:
+      actions: write
       contents: write
       pages: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     steps:
       - name: Download artifact
@@ -46,16 +47,12 @@ jobs:
           files: dist/*
           prerelease: ${{ contains(github.ref, '-') }}
 
-  update-website:
-    name: Update website
-    needs: github-release
-    if: ${{ !contains(github.ref, '-') }}
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    uses: ./.github/workflows/website.yml
-
+      - name: Trigger website update
+        if: ${{ !contains(github.ref, '-') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run --repo ${{ github.repository }} website.yml
+    
   docker-release:
     name: Publish container image to DockerHub
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,6 @@ on:
       - "website/**"
       - "docs/**"
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
-  workflow_call: # Allows you to run this workflow from another workflow
 
 permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
   contents: read


### PR DESCRIPTION
Now that `release.yml` can run directly under the context of a tag (#452), the workflow that updates the website after a release doesn't work anymore — and if it did, it could deploy an older version of the website!
This PR fixes that by trigger a workflow run on the default branch via `workflow_dispatch`, rather than reusing the workflow on the same reference via `workflow_call`. Yes, GitHub Actions can get pretty arcane 😬 