### PR TITLE
[release/0.3] Fix wrong Y axis scale in Aim UI when metric has infinity values

### DIFF
--- a/pkg/api/aim/runs.go
+++ b/pkg/api/aim/runs.go
@@ -1032,6 +1032,12 @@ func DeleteBatch(c *fiber.Ctx) error {
 func toNumpy(values []float64) fiber.Map {
 	buf := bytes.NewBuffer(make([]byte, 0, len(values)*8))
 	for _, v := range values {
+		switch v {
+		case math.MaxFloat64:
+			v = math.Inf(1)
+		case -math.MaxFloat64:
+			v = math.Inf(-1)
+		}
 		binary.Write(buf, binary.LittleEndian, v)
 	}
 	return fiber.Map{


### PR DESCRIPTION
Backport of #492. Fixes #489.