### PR TITLE
Improve S3 `CreateBuckets` and `RemoveBuckets` test helper functions.

### DIFF
--- a/tests/integration/golang/helpers/s3.go
+++ b/tests/integration/golang/helpers/s3.go
@@ -11,8 +11,6 @@ import (
 	"github.com/rotisserie/eris"
 )
 
-var testBuckets = []string{"bucket1", "bucket2"}
-
 // NewS3Client creates new instance of S3 client.
 func NewS3Client(endpoint string) (*s3.Client, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(context.Background(), awsConfig.WithEndpointResolverWithOptions(
@@ -37,8 +35,8 @@ func NewS3Client(endpoint string) (*s3.Client, error) {
 }
 
 // CreateBuckets creates the test bucekts.
-func CreateBuckets(s3Client *s3.Client) error {
-	for _, bucket := range testBuckets {
+func CreateBuckets(s3Client *s3.Client, buckets []string) error {
+	for _, bucket := range buckets {
 		_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
 			Bucket: aws.String(bucket),
 		})
@@ -50,8 +48,8 @@ func CreateBuckets(s3Client *s3.Client) error {
 }
 
 // RemoveBuckets removes the test buckets.
-func RemoveBuckets(s3Client *s3.Client) error {
-	for _, bucket := range testBuckets {
+func RemoveBuckets(s3Client *s3.Client, buckets []string) error {
+	for _, bucket := range buckets {
 		if err := removeBucket(s3Client, bucket); err != nil {
 			return eris.Wrapf(err, "failed to remove bucket '%s'", bucket)
 		}

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -26,11 +26,14 @@ import (
 type GetArtifactS3TestSuite struct {
 	suite.Suite
 	helpers.BaseTestSuite
-	s3Client *s3.Client
+	s3Client    *s3.Client
+	testBuckets []string
 }
 
 func TestGetArtifactS3TestSuite(t *testing.T) {
-	suite.Run(t, new(GetArtifactS3TestSuite))
+	suite.Run(t, &GetArtifactS3TestSuite{
+		testBuckets: []string{"bucket1", "bucket2"},
+	})
 }
 
 func (s *GetArtifactS3TestSuite) SetupTest() {
@@ -39,14 +42,14 @@ func (s *GetArtifactS3TestSuite) SetupTest() {
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
 	assert.Nil(s.T(), err)
 
-	err = helpers.CreateBuckets(s3Client)
+	err = helpers.CreateBuckets(s3Client, s.testBuckets)
 	assert.Nil(s.T(), err)
 
 	s.s3Client = s3Client
 }
 
 func (s *GetArtifactS3TestSuite) TearDownTest() {
-	err := helpers.RemoveBuckets(s.s3Client)
+	err := helpers.RemoveBuckets(s.s3Client, s.testBuckets)
 	assert.Nil(s.T(), err)
 }
 

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -28,11 +28,14 @@ import (
 type ListArtifactS3TestSuite struct {
 	suite.Suite
 	helpers.BaseTestSuite
-	s3Client *s3.Client
+	s3Client    *s3.Client
+	testBuckets []string
 }
 
 func TestListArtifactS3TestSuite(t *testing.T) {
-	suite.Run(t, new(ListArtifactS3TestSuite))
+	suite.Run(t, &ListArtifactS3TestSuite{
+		testBuckets: []string{"bucket1", "bucket2"},
+	})
 }
 
 func (s *ListArtifactS3TestSuite) SetupTest() {
@@ -41,14 +44,14 @@ func (s *ListArtifactS3TestSuite) SetupTest() {
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
 	assert.Nil(s.T(), err)
 
-	err = helpers.CreateBuckets(s3Client)
+	err = helpers.CreateBuckets(s3Client, s.testBuckets)
 	assert.Nil(s.T(), err)
 
 	s.s3Client = s3Client
 }
 
 func (s *ListArtifactS3TestSuite) TearDownTest() {
-	err := helpers.RemoveBuckets(s.s3Client)
+	err := helpers.RemoveBuckets(s.s3Client, s.testBuckets)
 	assert.Nil(s.T(), err)
 }
 


### PR DESCRIPTION
…t bucktes instead of to use global ones.