### PR TITLE
Improve Aim Python integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
 
   python-integration-tests:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
-    name: Python Integration Tests
+    name: Python Integration Tests (${{ matrix.api }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -214,7 +214,7 @@ jobs:
         with:
           cache-prefix: python-integration-tests
 
-      - name: Run ${{ matrix.api }} integration tests
+      - name: Run Python integration tests
         run: ./tests/integration/python/${{ matrix.api }}/test.sh
 
   build:

--- a/pkg/api/aim/projects.go
+++ b/pkg/api/aim/projects.go
@@ -205,7 +205,7 @@ func GetProjectParams(c *fiber.Ctx) error {
 
 			resp[s] = metrics
 		default:
-			return fmt.Errorf("%q is not a valid Sequence", s)
+			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("%q is not a valid Sequence", s))
 		}
 	}
 

--- a/pkg/api/aim/runs.go
+++ b/pkg/api/aim/runs.go
@@ -85,7 +85,7 @@ func GetRunInfo(c *fiber.Ctx) error {
 				return db.Select("RunID", "Key")
 			})
 		default:
-			return fmt.Errorf("%q is not a valid Sequence", s)
+			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("%q is not a valid Sequence", s))
 		}
 	}
 

--- a/tests/integration/python/aim/custom.patch
+++ b/tests/integration/python/aim/custom.patch
@@ -1,268 +1,201 @@
 diff --git a/tests/api/test_dashboards_api.py b/tests/api/test_dashboards_api.py
-index 94bc29c..3a8237d 100644
+index 94bc29c..85000fc 100644
 --- a/tests/api/test_dashboards_api.py
 +++ b/tests/api/test_dashboards_api.py
-@@ -1,3 +1,4 @@
-+from tests.utils import fill_up_fml_data, aim_client
- from tests.base import PrefilledDataApiTestBase
+@@ -1,7 +1,7 @@
+-from tests.base import PrefilledDataApiTestBase
++from tests.fml import ApiTestBase, db_fixtures
+ 
+-
+-class TestDashboardAppsApi(PrefilledDataApiTestBase):
++@db_fixtures()
++class TestDashboardAppsApi(ApiTestBase):
+     @classmethod
+     def setUpClass(cls) -> None:
+         super().setUpClass()
+@@ -53,7 +53,8 @@ class TestDashboardAppsApi(PrefilledDataApiTestBase):
+         self.assertEqual(app_data['type'], data['type'])
  
  
-@@ -10,7 +11,7 @@ class TestDashboardAppsApi(PrefilledDataApiTestBase):
- 
-     def test_list_apps_api(self):
-         response = self.client.get('/api/apps/')
--        self.assertEqual(5, len(response.json()))
-+        self.assertEqual(6, len(response.json()))
- 
-     def test_get_app_api(self):
-         list_response = self.client.get('/api/apps/')
-@@ -61,7 +62,8 @@ class TestDashboardsApi(PrefilledDataApiTestBase):
+-class TestDashboardsApi(PrefilledDataApiTestBase):
++@db_fixtures()
++class TestDashboardsApi(ApiTestBase):
+     @classmethod
+     def setUpClass(cls) -> None:
+         super().setUpClass()
+@@ -61,7 +62,7 @@ class TestDashboardsApi(PrefilledDataApiTestBase):
          response = cls.client.post('/api/apps/', json=app_data)
          cls.app_id = response.json()['id']
          for i in range(5):
 -            cls.client.post('/api/dashboards/', json={'name': f'dashboard_{i}'})
-+            cls.client.post('/api/dashboards/', json={'app_id': f'{cls.app_id}',
-+                            'name': f'dashboard_{i}', 'description': ''})
++            cls.client.post('/api/dashboards/', json={'name': f'dashboard_{i}', 'app_id': cls.app_id})
  
      def test_list_dashboards_api(self):
          response = self.client.get('/api/dashboards/')
-@@ -112,3 +114,51 @@ class TestDashboardsApi(PrefilledDataApiTestBase):
-         self.assertEqual(200, response.status_code)
-         get_response = self.client.get(f'/api/dashboards/{dashboard_id}/')
-         self.assertEqual(404, get_response.status_code)
-+
-+
-+class SQliteKeyTest(TestDashboardAppsApi, TestDashboardsApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("sqlite+key")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-+
-+
-+class SQliteMemoryTest(TestDashboardAppsApi, TestDashboardsApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("sqlite+memory")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-+
-+
-+class SQliteFileTest(TestDashboardAppsApi, TestDashboardsApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("sqlite+file")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-+
-+
-+class PostgresTest(TestDashboardAppsApi, TestDashboardsApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("postgres")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
 diff --git a/tests/api/test_project_api.py b/tests/api/test_project_api.py
-index 31d3654..9e5e10b 100644
+index 31d3654..060d528 100644
 --- a/tests/api/test_project_api.py
 +++ b/tests/api/test_project_api.py
-@@ -1,7 +1,7 @@
+@@ -1,21 +1,17 @@
  import pytz
--
-+import unittest
- from tests.base import PrefilledDataApiTestBase, ApiTestBase
+ 
+-from tests.base import PrefilledDataApiTestBase, ApiTestBase
 -from tests.utils import generate_image_set
-+from tests.utils import generate_image_set, aim_client, create_experiment
++from tests.fml import ApiTestBase, db_fixtures
  
  from parameterized import parameterized
  import datetime
-@@ -11,10 +11,9 @@ from aim.sdk.run import Run
  
- class TestProjectApi(PrefilledDataApiTestBase):
+-from aim.sdk.run import Run
+-
+-
+-class TestProjectApi(PrefilledDataApiTestBase):
++@db_fixtures()
++class TestProjectApi(ApiTestBase):
      def test_project_activity_api(self):
 -        with self.repo.structured_db as db:
 -            db.create_experiment('My experiment')
-+        create_experiment('My experiment')
++        self.create_experiment('My experiment')
  
 -        experiment_count = len(self.repo.structured_db.experiments())
-+        experiment_count = len(self.repo.structured_db.experiments()) + 2  # default experiment and my experiment
-         run_count = len(self.repo.structured_db.runs())
+-        run_count = len(self.repo.structured_db.runs())
++        experiment_count = 2  # default experiment and my experiment
++        run_count = 10
          client = self.client
          response = client.get('/api/projects/activity')
-@@ -22,9 +21,10 @@ class TestProjectApi(PrefilledDataApiTestBase):
-         data = response.json()
-         today_gmt = datetime.datetime.now().astimezone(pytz.timezone('gmt')).strftime('%Y-%m-%dT%H:00:00')
-         self.assertEqual(run_count, data['num_runs'])
--        self.assertEqual(run_count, data['activity_map'][today_gmt])
-+        # self.assertEqual(run_count, data['activity_map'][today_gmt])
-         self.assertEqual(experiment_count, data['num_experiments'])  # count 'default' experiment
+         self.assertEqual(200, response.status_code)
+@@ -36,25 +32,24 @@ class TestProjectApi(PrefilledDataApiTestBase):
+         self.assertEqual({}, data['images'])
+         self.assertSetEqual({'accuracy', 'loss'}, set(data['metric']))
+         self.assertIn('hparams', data['params'])
+-        self.assertIn('batch_size', data['params']['hparams'])
+-        self.assertIn('lr', data['params']['hparams'])
++        # TODO requires nested params support
++        # self.assertIn('batch_size', data['params']['hparams'])
++        # self.assertIn('lr', data['params']['hparams'])
+         self.assertIn('name', data['params'])
+         self.assertIn('run_index', data['params'])
+         self.assertIn('start_time', data['params'])
  
-+    @unittest.skip('empty map response')
-     def test_project_params_api(self):
-         client = self.client
-         response = client.get('/api/projects/params')
-@@ -47,6 +47,7 @@ class TestProjectParamsWithImagesApi(ApiTestBase):
+ 
++@db_fixtures()
+ class TestProjectParamsWithImagesApi(ApiTestBase):
      @classmethod
      def setUpClass(cls) -> None:
          super().setUpClass()
-+        '''
-         run1 = Run(system_tracking_interval=None)
-         run1.track(1., name='metric1', context={'a': True})
-         run1.track(generate_image_set(1), name='images1', context={'a': True})
-@@ -55,11 +56,13 @@ class TestProjectParamsWithImagesApi(ApiTestBase):
-         run2 = Run(system_tracking_interval=None)
-         run2.track(1, name='metric2', context={'a': True})
-         run2.track(generate_image_set(1)[0], name='images2', context={'b': True})
-+        '''
+-        run1 = Run(system_tracking_interval=None)
+-        run1.track(1., name='metric1', context={'a': True})
+-        run1.track(generate_image_set(1), name='images1', context={'a': True})
+-        run1.track(generate_image_set(1), name='images1', context={'b': True})
++        run1 = cls.create_run("Run # 1", "0")
++        cls.log_metric(run1, "metric1", 1, 0)
+ 
+-        run2 = Run(system_tracking_interval=None)
+-        run2.track(1, name='metric2', context={'a': True})
+-        run2.track(generate_image_set(1)[0], name='images2', context={'b': True})
++        run2 = cls.create_run("Run # 2", "0")
++        cls.log_metric(run2, "metric2", 1, 0)
  
      @parameterized.expand([
          ({'sequence': ('metric', 'images')},),  # metrics only
-         (None,)                                 # default
-     ])
-+    @unittest.skip('empty map response')
-     def test_project_images_and_metric_info_api(self, qparams):
+@@ -70,18 +65,20 @@ class TestProjectParamsWithImagesApi(ApiTestBase):
+         self.assertIn('images', data)
+ 
+         self.assertTrue({'metric1', 'metric2'}.issubset(set(data['metric'].keys())))
+-        self.assertTrue({'images1', 'images2'}.issubset(set(data['images'].keys())))
++        # TODO requires image support
++        # self.assertTrue({'images1', 'images2'}.issubset(set(data['images'].keys())))
+ 
+         self.assertEqual(1, len(data['metric']['metric1']))
+-        self.assertDictEqual({'a': 1}, data['metric']['metric1'][0])
+-
+-        self.assertEqual(2, len(data['images']['images1']))
+-
++        # TODO requires context support
++        # self.assertDictEqual({'a': 1}, data['metric']['metric1'][0])
++        # TODO requires image support
++        # self.assertEqual(2, len(data['images']['images1']))
+         self.assertEqual(1, len(data['metric']['metric2']))
+-        self.assertDictEqual({'a': 1}, data['metric']['metric2'][0])
+-
+-        self.assertEqual(1, len(data['images']['images2']))
+-        self.assertDictEqual({'b': 1}, data['images']['images2'][0])
++        # TODO requires context support
++        # self.assertDictEqual({'a': 1}, data['metric']['metric2'][0])
++        # TODO requires image support
++        # self.assertEqual(1, len(data['images']['images2']))
++        # self.assertDictEqual({'b': 1}, data['images']['images2'][0])
+ 
+     def test_project_images_info_only_api(self):
          client = self.client
-         response = client.get('/api/projects/params', params=qparams)
-@@ -101,7 +104,56 @@ class TestProjectParamsWithImagesApi(ApiTestBase):
-         self.assertIn('metric', data)
-         self.assertNotIn('images', data)
- 
-+    @unittest.skip('wrong status code')
-     def test_invalid_sequence_type(self):
-         client = self.client
-         response = client.get('/api/projects/params', params={'sequence': 'non-existing-sequence'})
-         self.assertEqual(400, response.status_code)
-+
-+
-+class SQliteKeyTest(TestProjectApi, TestProjectParamsWithImagesApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("sqlite+key")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-+
-+
-+class SQliteMemoryTest(TestProjectApi, TestProjectParamsWithImagesApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("sqlite+memory")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-+
-+
-+class SQliteFileTest(TestProjectApi, TestProjectParamsWithImagesApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("sqlite+file")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-+
-+
-+class PostgresTest(TestProjectApi, TestProjectParamsWithImagesApi):
-+    @classmethod
-+    def setUpClass(cls):
-+        cls.db_path, cls.client, cls.process = aim_client("postgres")
-+        super().setUpClass()
-+
-+    @classmethod
-+    def tearDownClass(cls):
-+        cls.process.terminate()
-+        super().tearDownClass()
-diff --git a/tests/base.py b/tests/base.py
-index 0ebd14d..7b92910 100644
---- a/tests/base.py
-+++ b/tests/base.py
-@@ -1,7 +1,8 @@
- import unittest
-+import httpx
- from fastapi.testclient import TestClient
- 
--from tests.utils import truncate_api_db, full_class_name, fill_up_test_data
-+from tests.utils import truncate_api_db, full_class_name, fill_up_test_data, fill_up_fml_data
- from aim.sdk.repo import Repo
- from aim.sdk.run import Run
- 
-@@ -38,13 +39,13 @@ class PrefilledDataTestBase(TestBase):
-     def setUpClass(cls) -> None:
-         super().setUpClass()
-         fill_up_test_data(extra_params={'testcase': full_class_name(cls)})
-+        fill_up_fml_data(cls.repo)
- 
- 
- class ApiTestBase(TestBase):
-     @classmethod
-     def setUpClass(cls) -> None:
-         super().setUpClass()
--        cls.client = TestClient(app)
- 
-     @classmethod
-     def tearDownClass(cls) -> None:
-diff --git a/tests/requirements.txt b/tests/requirements.txt
-index 61cf41a..97aee6c 100644
---- a/tests/requirements.txt
-+++ b/tests/requirements.txt
-@@ -9,3 +9,5 @@ pytest
- flake8
- parameterized==0.8.1
- pytest-cov==2.12.1
-+psycopg2-binary
-+httpx
-diff --git a/tests/utils.py b/tests/utils.py
-index dd1874e..29de29c 100644
---- a/tests/utils.py
-+++ b/tests/utils.py
-@@ -3,6 +3,18 @@ import itertools
- import os.path
- import shutil
- import numpy
-+import httpx
-+import socket
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 8cdd353..e69de29 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -1,44 +0,0 @@
+-import os
+-import shutil
+-
+-from aim.sdk.repo import Repo, _get_tracking_queue
+-from aim.web.utils import exec_cmd
+-from aim.cli.up.utils import build_db_upgrade_command
+-from aim.web.configs import AIM_ENV_MODE_KEY
+-from aim.sdk.configs import AIM_ENABLE_TRACKING_THREAD, AIM_REPO_NAME
+-from aim.utils.tracking import analytics
+-
+-TEST_REPO_PATH = '.aim-test-repo'
+-
+-
+-def _init_test_repo():
+-    repo = Repo.default_repo(init=True)
+-    # some unittests check sequence tracking in a separate thread
+-    # need to make sure task_queue is there
+-    os.environ[AIM_ENABLE_TRACKING_THREAD] = 'ON'
+-    Repo.tracking_queue = _get_tracking_queue()
+-    del os.environ[AIM_ENABLE_TRACKING_THREAD]
+-
+-
+-def _cleanup_test_repo(path):
+-    shutil.rmtree(TEST_REPO_PATH)
+-
+-
+-def _upgrade_api_db():
+-    db_cmd = build_db_upgrade_command()
+-    exec_cmd(db_cmd, stream_output=True)
+-
+-
+-def pytest_sessionstart(session):
+-    analytics.dev_mode = True
+-
+-    os.environ[AIM_REPO_NAME] = TEST_REPO_PATH
+-    os.environ[AIM_ENV_MODE_KEY] = 'test'
+-
+-    _init_test_repo()
+-    _upgrade_api_db()
+-
+-
+-def pytest_sessionfinish(session, exitstatus):
+-    _cleanup_test_repo(TEST_REPO_PATH)
+-    del os.environ[AIM_REPO_NAME]
+diff --git a/tests/fml.py b/tests/fml.py
+new file mode 100644
+index 0000000..099cab0
+--- /dev/null
++++ b/tests/fml.py
+@@ -0,0 +1,199 @@
++import datetime
++import itertools
 +import os
++import socket
 +import tempfile
 +import time
-+import numpy
-+import httpx
-+import uuid
-+import socket
-+import psycopg2
-+import sqlite3
++import unittest
 +from subprocess import Popen
- from PIL import Image as pil_image
- 
- from typing import Iterator
-@@ -16,6 +28,73 @@ from aim.storage.structured.sql_engine.models import Base as StructuredBase
- from aim.web.api.db import get_contexted_session
- from aim.web.api.db import Base as ApiBase
- 
-+LOCALHOST = '127.0.0.1'
++
++import httpx
++from parameterized import parameterized_class
++
++LOCALHOST = "127.0.0.1"
 +
 +
 +def get_safe_port():
@@ -274,28 +207,9 @@ index dd1874e..29de29c 100644
 +    return port
 +
 +
-+PORT = get_safe_port()
-+
-+
-+def aim_client(db):
-+    temp_dir = tempfile.mkdtemp()
-+
-+    if db == "sqlite+memory":
-+        db_path = f"sqlite://{temp_dir}/sqlalchemy.db?mode=memory&cache=shared"
-+    elif db == "sqlite+file":
-+        db_path = f"sqlite://{temp_dir}/sqlalchemy.db?_journal_mode=WAL"
-+    elif db == "sqlite+key":
-+        db_path = f"sqlite://{temp_dir}/sqlalchemy.db?_key=passphrase&_journal_mode=WAL"
-+    elif db == "postgres":
-+        db_path = "postgres://postgres:postgres@localhost/test"
-+    else:
-+        raise ValueError(f"Database '{db}' not supported.")
-+    process = init_server(db_path, temp_dir)
-+
-+    return db_path, httpx.Client(base_url=f"http://127.0.0.1:{PORT}/aim"), process
-+
-+
 +def init_server(backend_uri, root_artifact_uri):
++    port = get_safe_port()
++    address = f"{LOCALHOST}:{port}"
 +    process = Popen(
 +        [
 +            "fml",
@@ -303,15 +217,15 @@ index dd1874e..29de29c 100644
 +        ],
 +        env={
 +            **os.environ,
-+            "FML_LISTEN_ADDRESS": f"{LOCALHOST}:{PORT}",
++            "FML_LISTEN_ADDRESS": address,
 +            "FML_DATABASE_URI": backend_uri,
-+            "FML_ARTIFACT_ROOT": root_artifact_uri,
++            "FML_DEFAULT_ARTIFACT_ROOT": root_artifact_uri,
 +            "FML_LOG_LEVEL": "debug",
-+            "FML_DATABASE_RESET": str(backend_uri.startswith("postgres://")),
++            "FML_DATABASE_RESET": str(backend_uri.startswith("postgres")),
 +        },
 +    )
-+    await_server_up_or_die(PORT)
-+    return process
++    await_server_up_or_die(port)
++    return address, process
 +
 +
 +def await_server_up_or_die(port, timeout=60):
@@ -327,82 +241,144 @@ index dd1874e..29de29c 100644
 +        else:
 +            time.sleep(0.5)
 +    if not connected:
-+        raise Exception(f"Failed to connect on {LOCALHOST}:{port} after {timeout} seconds")
-+
- 
- def decode_encoded_tree_stream(stream: Iterator[bytes], concat_chunks=False) -> bytes:
-     # TODO: handle case when chunk ends at the middle of key/value
-@@ -120,6 +199,73 @@ def fill_up_test_data(extra_params: dict = None):
-             run.finalize()
- 
- 
-+def insert_data_sqlite(queries, db_path):
-+    conn = sqlite3.connect("sqlalchemy.db")
-+    cursor = conn.cursor()
-+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
-+    conn.close()
++        raise Exception(
++            f"Failed to connect on {LOCALHOST}:{port} after {timeout} seconds"
++        )
 +
 +
-+def insert_data_postgresql(queries, db_uri):
-+    conn = psycopg2.connect(db_uri)
-+    cursor = conn.cursor()
-+    cursor.execute(queries)
-+    conn.commit()
-+    conn.close()
++def get_current_timestamp():
++    return int(datetime.datetime.utcnow().timestamp() * 1000)
 +
 +
-+def insert_data(queries, db_path):
-+    if "postgres" in db_path:
-+        insert_data_postgresql(queries, db_path)
-+    else:
-+        insert_data_sqlite(queries, db_path)
++def db_fixtures():
++    return parameterized_class(
++        "db",
++        [
++            ["sqlite+memory"],
++            ["sqlite+file"],
++            ["sqlite+key"],
++            ["postgres"],
++        ],
++    )
 +
 +
-+def create_experiment(name):
-+    client = httpx.Client(base_url=f"http://127.0.0.1:{PORT}/api/2.0/mlflow")
-+    response = client.post('/experiments/create', json={'name': name})
-+    data = response.json()
-+    return data['experiment_id']
++class ApiTestBase(unittest.TestCase):
++    @classmethod
++    def setUpClass(cls) -> None:
++        super().setUpClass()
 +
++        cls.temp_dir = tempfile.TemporaryDirectory()
++        dir_name = cls.temp_dir.name
 +
-+def fill_up_fml_data(repo):
-+    client = httpx.Client(base_url=f"http://127.0.0.1:{PORT}/api/2.0/mlflow")
-+    contexts = [{'is_training': True, 'subset': 'train'},
-+                {'is_training': True, 'subset': 'val'},
-+                {'is_training': False}]
-+    metrics = ['loss', 'accuracy']
-+    exp_id = create_experiment('default')
-+    for run in repo.iter_runs():
-+        dateStr = int(time.mktime(datetime.datetime.strptime(run['start_time'], "%Y-%m-%dT%H:%M:%S.%f").timetuple()))
-+        response = client.post('/runs/create', json={'name': run.name, 'experiment_id': exp_id, 'start_time': dateStr})
-+        data = response.json()['run']['info']
-+        client.post('/runs/log-parameter', json={'key': 'hparams',
-+                    'value': "{\'lr\': 0.001, \'batch_size\': 0}", 'run_uuid': data['run_uuid']})
-+        client.post('/runs/log-parameter', json={'key': 'run_index',
-+                    'value': str(run['run_index']), 'run_uuid': data['run_uuid']})
-+        client.post('/runs/log-parameter', json={'key': 'start_time',
-+                    'value': str(run['start_time']), 'run_uuid': data['run_uuid']})
-+        client.post('/runs/log-parameter', json={'key': 'name',
-+                    'value': str(run['name']), 'run_uuid': data['run_uuid']})
-+        client.post('/runs/log-parameter', json={'key': 'testcase',
-+                    'value': str(run['testcase']), 'run_uuid': data['run_uuid']})
-+        metric_contexts = itertools.product(metrics, contexts)
-+        for metric_context in metric_contexts:
-+            metric = metric_context[0]
-+            context = metric_context[1]
-+            if metric == 'accuracy' and 'subset' in context:
-+                continue
-+            else:
++        if cls.db == "sqlite+memory":
++            db_path = f"sqlite://{dir_name}/fml.db?mode=memory&cache=shared"
++        elif cls.db == "sqlite+file":
++            db_path = f"sqlite://{dir_name}/fml.db"
++        elif cls.db == "sqlite+key":
++            db_path = f"sqlite://{dir_name}/fml.db?_key=passphrase"
++        elif cls.db == "postgres":
++            db_path = "postgres://postgres:postgres@localhost/test"
++        else:
++            raise ValueError(f"Database '{cls.db}' not supported.")
++
++        address, cls.process = init_server(db_path, dir_name)
++
++        cls.client = httpx.Client(base_url=f"http://{address}/aim")
++        cls.mlflow_client = httpx.Client(base_url=f"http://{address}/api/2.0/mlflow")
++
++        cls.fill_up_fml_data()
++
++    @classmethod
++    def tearDownClass(cls):
++        super().tearDownClass()
++        cls.process.terminate()
++        cls.temp_dir.cleanup()
++
++    @classmethod
++    def create_experiment(cls, name):
++        response = cls.mlflow_client.post("/experiments/create", json={"name": name})
++        return response.json()["experiment_id"]
++
++    @classmethod
++    def create_run(cls, name, experiment_id):
++        response = cls.mlflow_client.post(
++            "/runs/create",
++            json={
++                "name": name,
++                "experiment_id": experiment_id,
++                "start_time": get_current_timestamp(),
++            },
++        )
++        return response.json()["run"]["info"]["run_uuid"]
++
++    @classmethod
++    def log_metric(cls, run_id, key, value, step):
++        cls.mlflow_client.post(
++            "/runs/log-metric",
++            json={
++                "key": key,
++                "value": value,
++                "timestamp": get_current_timestamp(),
++                "run_id": run_id,
++                "step": step,
++            },
++        )
++
++    @classmethod
++    def log_param(cls, run_id, key, value):
++        cls.mlflow_client.post(
++            "/runs/log-parameter",
++            json={
++                "key": key,
++                "value": value,
++                "run_id": run_id,
++            },
++        )
++
++    @classmethod
++    def log_metrics(cls, run_id, metrics):
++        cls.mlflow_client.post(
++            "/runs/log-batch",
++            json={
++                "run_id": run_id,
++                "metrics": metrics,
++            },
++        )
++
++    @classmethod
++    def log_params(cls, run_id, params):
++        cls.mlflow_client.post(
++            "/runs/log-batch",
++            json={
++                "run_id": run_id,
++                "params": [{"key": k, "value": v} for k, v in params.items()],
++            },
++        )
++
++    @classmethod
++    def fill_up_fml_data(cls):
++        for idx in range(10):
++            run_id = cls.create_run(f"Run # {idx}", "0")
++            cls.log_params(
++                run_id,
++                {
++                    "hparams": "",
++                    "run_index": str(idx),
++                    "start_time": datetime.datetime.utcnow().ctime(),
++                    "name": f"Run # {idx}",
++                },
++            )
++            metrics = []
++            for metric in ["loss", "accuracy"]:
 +                # track 100 values per run
-+                registered_metrics = []
 +                for step in range(100):
 +                    val = 1.0 - 1.0 / (step + 1)
-+                    if metric not in registered_metrics:
-+                        client.post('/runs/log-metric', json={'key': metric, 'value': val,
-+                                    'timestamp': dateStr, 'run_uuid': data['run_uuid'], 'step': step})
-+                        registered_metrics.append(metric)
-+
-+
- def is_package_installed(pkg_name: str) -> bool:
-     import importlib
-     try:
++                    metrics.append(
++                        {
++                            "key": metric,
++                            "value": val,
++                            "timestamp": get_current_timestamp(),
++                            "step": step,
++                        }
++                    )
++            cls.log_metrics(run_id, metrics)

--- a/tests/integration/python/aim/test.sh
+++ b/tests/integration/python/aim/test.sh
@@ -31,7 +31,7 @@ if [ ! -d ${venv} ]
 then
   python -mvenv ${venv}
   . ${venv}/bin/activate
-  pip install -r tests/requirements.txt 
+  pip install httpx parameterized pytest pytz 
   deactivate
 fi
 
@@ -48,5 +48,4 @@ EOF
 # Run tests
 . ${venv}/bin/activate
 export PATH=".:${PATH}"
-pytest tests/api/test_dashboards_api.py  -k "SQliteKeyTest or SQliteMemoryTest or SQliteFileTest or PostgresTest"
-pytest tests/api/test_project_api.py -k "SQliteKeyTest or SQliteMemoryTest or SQliteFileTest or PostgresTest"
+pytest tests/api/test_dashboards_api.py tests/api/test_project_api.py


### PR DESCRIPTION
This PR is the fifth in a series to address #328.

It makes the Aim Python integration tests setup lighter by ditching the unused Aim fixtures. It also makes them more accurate by fixing the server rather than the tests. Finally, it enables more tests that were previously skipped.