### PR TITLE
DB schema: rename experiments unique index

### DIFF
--- a/pkg/api/mlflow/dao/models/experiment.go
+++ b/pkg/api/mlflow/dao/models/experiment.go
@@ -7,12 +7,12 @@ import (
 // Experiment represents model to work with `experiments` table.
 type Experiment struct {
 	ID               *int32         `gorm:"column:experiment_id;not null;primaryKey"`
-	Name             string         `gorm:"type:varchar(256);not null;index:idx_namespace_name,unique"`
+	Name             string         `gorm:"type:varchar(256);not null;index:,unique,composite:name"`
 	ArtifactLocation string         `gorm:"type:varchar(256)"`
 	LifecycleStage   LifecycleStage `gorm:"type:varchar(32);check:lifecycle_stage IN ('active', 'deleted')"`
 	CreationTime     sql.NullInt64  `gorm:"type:bigint"`
 	LastUpdateTime   sql.NullInt64  `gorm:"type:bigint"`
-	NamespaceID      uint           `gorm:"index:idx_namespace_name,unique"`
+	NamespaceID      uint           `gorm:"index:,unique,composite:name"`
 	Namespace        Namespace
 	Tags             []ExperimentTag `gorm:"constraint:OnDelete:CASCADE"`
 	Runs             []Run           `gorm:"constraint:OnDelete:CASCADE"`

--- a/pkg/database/migrations/v_0006/migrate.go
+++ b/pkg/database/migrations/v_0006/migrate.go
@@ -31,7 +31,7 @@ func Migrate(db *gorm.DB) error {
 			if err := tx.Migrator().AlterColumn(&Experiment{}, "Name"); err != nil {
 				return err
 			}
-			if err := tx.Migrator().CreateIndex(&Experiment{}, "idx_namespace_name"); err != nil {
+			if err := tx.Migrator().CreateIndex(&Experiment{}, "Name"); err != nil {
 				return err
 			}
 			return tx.Model(&SchemaVersion{}).

--- a/pkg/database/migrations/v_0006/model.go
+++ b/pkg/database/migrations/v_0006/model.go
@@ -44,12 +44,12 @@ type Namespace struct {
 
 type Experiment struct {
 	ID               *int32         `gorm:"column:experiment_id;not null;primaryKey"`
-	Name             string         `gorm:"type:varchar(256);not null;index:idx_namespace_name,unique"`
+	Name             string         `gorm:"type:varchar(256);not null;index:,unique,composite:name"`
 	ArtifactLocation string         `gorm:"type:varchar(256)"`
 	LifecycleStage   LifecycleStage `gorm:"type:varchar(32);check:lifecycle_stage IN ('active', 'deleted')"`
 	CreationTime     sql.NullInt64  `gorm:"type:bigint"`
 	LastUpdateTime   sql.NullInt64  `gorm:"type:bigint"`
-	NamespaceID      uint           `gorm:"index:idx_namespace_name,unique"`
+	NamespaceID      uint           `gorm:"index:,unique,composite:name"`
 	Namespace        Namespace
 	Tags             []ExperimentTag `gorm:"constraint:OnDelete:CASCADE"`
 	Runs             []Run           `gorm:"constraint:OnDelete:CASCADE"`

--- a/pkg/database/model.go
+++ b/pkg/database/model.go
@@ -44,12 +44,12 @@ type Namespace struct {
 
 type Experiment struct {
 	ID               *int32         `gorm:"column:experiment_id;not null;primaryKey"`
-	Name             string         `gorm:"type:varchar(256);not null;index:idx_namespace_name,unique"`
+	Name             string         `gorm:"type:varchar(256);not null;index:,unique,composite:name"`
 	ArtifactLocation string         `gorm:"type:varchar(256)"`
 	LifecycleStage   LifecycleStage `gorm:"type:varchar(32);check:lifecycle_stage IN ('active', 'deleted')"`
 	CreationTime     sql.NullInt64  `gorm:"type:bigint"`
 	LastUpdateTime   sql.NullInt64  `gorm:"type:bigint"`
-	NamespaceID      uint           `gorm:"index:idx_namespace_name,unique"`
+	NamespaceID      uint           `gorm:"index:,unique,composite:name"`
 	Namespace        Namespace
 	Tags             []ExperimentTag `gorm:"constraint:OnDelete:CASCADE"`
 	Runs             []Run           `gorm:"constraint:OnDelete:CASCADE"`


### PR DESCRIPTION
Fixes #567 by using a proper composite index that relies on Gorm's naming strategy instead of a hardcoded one.