### PR TITLE
Use `require` instead of `assert` for checking errors in tests

### DIFF
--- a/pkg/api/admin/service/namespace/service_test.go
+++ b/pkg/api/admin/service/namespace/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/repositories"
@@ -39,7 +40,7 @@ func TestService_CreateNamespace_Ok(t *testing.T) {
 	_, err := service.CreateNamespace(context.TODO(), "code", "description")
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_CreateNamespace_Error(t *testing.T) {
@@ -83,7 +84,7 @@ func TestService_GetNamespace_Ok(t *testing.T) {
 	namespace, err := service.GetNamespace(context.TODO(), uint(0))
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, &ns, namespace)
 }
 
@@ -127,7 +128,7 @@ func TestService_ListNamespace_Ok(t *testing.T) {
 	namespaces, err := service.ListNamespaces(context.TODO())
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, testNamespaces, namespaces)
 }
 
@@ -170,7 +171,7 @@ func TestService_DeleteNamespace_Ok(t *testing.T) {
 	err := service.DeleteNamespace(context.TODO(), uint(0))
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_DeleteNamespace_Error(t *testing.T) {
@@ -215,7 +216,7 @@ func TestService_UpdateNamespace_Ok(t *testing.T) {
 	_, err := service.UpdateNamespace(context.TODO(), uint(1), "code", "description")
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_UpdateNamespace_Error(t *testing.T) {

--- a/pkg/api/admin/service/namespace/validator_test.go
+++ b/pkg/api/admin/service/namespace/validator_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 )
 
 func TestValidateUpdateRunRequest_Ok(t *testing.T) {
 	err := ValidateNamespace("legit-123_ns")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateUpdateRunRequest_Error(t *testing.T) {

--- a/pkg/api/aim/query/query_test.go
+++ b/pkg/api/aim/query/query_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -24,13 +25,13 @@ func TestQueryTestSuite(t *testing.T) {
 
 func (s *QueryTestSuite) SetupTest() {
 	mockedDB, _, err := sqlmock.New()
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	db, err := gorm.Open(postgres.New(postgres.Config{
 		Conn:       mockedDB,
 		DriverName: "postgres",
 	}), &gorm.Config{})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	s.db = db
 }
 
@@ -136,11 +137,11 @@ func (s *QueryTestSuite) TestPostgresDialector_Ok() {
 				Dialector: postgres.Dialector{}.Name(),
 			}
 			parsedQuery, err := pq.Parse(tt.query)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			result := parsedQuery.Filter(
 				s.db.Session(&gorm.Session{DryRun: true}).Model(models.Run{}),
 			).Select("ID").Find(&models.Run{})
-			assert.Nil(s.T(), result.Error)
+			require.Nil(s.T(), result.Error)
 			assert.Equal(s.T(), tt.expectedSQL, result.Statement.SQL.String())
 			assert.Equal(s.T(), tt.expectedVars, result.Statement.Vars)
 		})
@@ -249,11 +250,11 @@ func (s *QueryTestSuite) TestSqliteDialector_Ok() {
 				Dialector: sqlite.Dialector{}.Name(),
 			}
 			parsedQuery, err := pq.Parse(tt.query)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			result := parsedQuery.Filter(
 				s.db.Session(&gorm.Session{DryRun: true}).Model(models.Run{}),
 			).Select("ID").Find(&models.Run{})
-			assert.Nil(s.T(), result.Error)
+			require.Nil(s.T(), result.Error)
 			assert.Equal(s.T(), tt.expectedSQL, result.Statement.SQL.String())
 			assert.Equal(s.T(), tt.expectedVars, result.Statement.Vars)
 		})

--- a/pkg/api/aim/runs_test.go
+++ b/pkg/api/aim/runs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/query"
 )
@@ -92,7 +93,7 @@ func Test_isMetricSelected(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				pq, err := qp.Parse(tt.query)
-				assert.Nil(t, err)
+				require.Nil(t, err)
 				assert.Equal(t, tt.wantResult, pq.IsMetricSelected())
 			})
 		}

--- a/pkg/api/mlflow/config/config_test.go
+++ b/pkg/api/mlflow/config/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceConfig_Validate_Ok(t *testing.T) {
@@ -31,7 +32,7 @@ func TestServiceConfig_Validate_Ok(t *testing.T) {
 			expectedConfig: &ServiceConfig{
 				DefaultArtifactRoot: (func() string {
 					path, err := filepath.Abs("path1/path2/path3")
-					assert.Nil(t, err)
+					require.Nil(t, err)
 					return path
 				})(),
 			},
@@ -62,7 +63,7 @@ func TestServiceConfig_Validate_Ok(t *testing.T) {
 			expectedConfig: &ServiceConfig{
 				DefaultArtifactRoot: (func() string {
 					path, err := filepath.Abs("path1/path2/path3")
-					assert.Nil(t, err)
+					require.Nil(t, err)
 					return path
 				})(),
 			},
@@ -71,7 +72,7 @@ func TestServiceConfig_Validate_Ok(t *testing.T) {
 
 	for _, tt := range testData {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Nil(t, tt.providedConfig.Validate())
+			require.Nil(t, tt.providedConfig.Validate())
 			assert.Equal(t, tt.providedConfig.DefaultArtifactRoot, tt.expectedConfig.DefaultArtifactRoot)
 		})
 	}

--- a/pkg/api/mlflow/dao/convertors/experiment_test.go
+++ b/pkg/api/mlflow/dao/convertors/experiment_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
@@ -21,7 +22,7 @@ func TestConvertCreateExperimentToDBModel_Ok(t *testing.T) {
 		ArtifactLocation: "s3://location",
 	}
 	result, err := ConvertCreateExperimentToDBModel(&req)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "name", result.Name)
 	assert.Equal(t, models.LifecycleStageActive, result.LifecycleStage)
 	assert.Equal(t, "s3://location", result.ArtifactLocation)

--- a/pkg/api/mlflow/dao/convertors/log_test.go
+++ b/pkg/api/mlflow/dao/convertors/log_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
@@ -42,7 +43,7 @@ func TestConvertLogBatchRequestToDBModel_Ok(t *testing.T) {
 		},
 	}
 	metrics, params, tags, err := ConvertLogBatchRequestToDBModel("run_id", &req)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, []models.Tag{
 		{
 			RunID: "run_id",

--- a/pkg/api/mlflow/dao/convertors/metric_test.go
+++ b/pkg/api/mlflow/dao/convertors/metric_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 )
@@ -17,7 +18,7 @@ func TestConvertMetricParamRequestToDBModel(t *testing.T) {
 		Timestamp: 1234567890,
 	}
 	result, err := ConvertMetricParamRequestToDBModel("run_id", &req)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "key", result.Key)
 	assert.Equal(t, int64(1), result.Step)
 	assert.Equal(t, 1.1, result.Value)

--- a/pkg/api/mlflow/dao/convertors/run_test.go
+++ b/pkg/api/mlflow/dao/convertors/run_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
@@ -184,7 +185,7 @@ func TestConvertCreateRunRequestToDBModel(t *testing.T) {
 				ID:               &experimentID,
 				ArtifactLocation: "artifact_location",
 			}, tt.req)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			tt.result(result)
 		})
 	}

--- a/pkg/api/mlflow/dao/repositories/run_test.go
+++ b/pkg/api/mlflow/dao/repositories/run_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
@@ -47,7 +48,7 @@ func Test_renumberRows(t *testing.T) {
 		DriverName: "postgres",
 	})
 	db, err := gorm.Open(dialector, &gorm.Config{})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	repo := NewRunRepository(db)
 

--- a/pkg/api/mlflow/service/artifact/service_test.go
+++ b/pkg/api/mlflow/service/artifact/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -62,7 +63,7 @@ func TestService_ListArtifacts_Ok(t *testing.T) {
 		},
 	)
 
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "/artifact/uri", rootURI)
 	assert.Equal(t, []storage.ArtifactObject{
 		{

--- a/pkg/api/mlflow/service/artifact/storage/helpers_test.go
+++ b/pkg/api/mlflow/service/artifact/storage/helpers_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractS3BucketAndPrefix_Ok(t *testing.T) {
 	uri := "s3://fasttrackml/2/30357ed2eaac4f2cacdbcd0e06e9e48a/artifacts"
 	bucket, prefix, err := ExtractBucketAndPrefix(uri)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "fasttrackml", bucket)
 	assert.Equal(t, "2/30357ed2eaac4f2cacdbcd0e06e9e48a/artifacts", prefix)
 }

--- a/pkg/api/mlflow/service/artifact/storage/local_test.go
+++ b/pkg/api/mlflow/service/artifact/storage/local_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetArtifact_Ok(t *testing.T) {
@@ -18,16 +19,16 @@ func TestGetArtifact_Ok(t *testing.T) {
 
 	// #nosec G304
 	f, err := os.Create(filepath.Join(runArtifactRoot, fileName))
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = f.Write([]byte(fileContent))
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// invoke
 	storage, err := NewLocal(nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	file, err := storage.Get(context.Background(), runArtifactRoot, fileName)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	//nolint:errcheck
 	defer file.Close()
 
@@ -35,7 +36,7 @@ func TestGetArtifact_Ok(t *testing.T) {
 	assert.NotNil(t, file)
 	readBuffer := make([]byte, 20)
 	ln, err := file.Read(readBuffer)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, fileContent, string(readBuffer[:ln]))
 }
 
@@ -45,11 +46,11 @@ func TestGetArtifact_Error(t *testing.T) {
 	subdir := "subdir"
 
 	err := os.MkdirAll(filepath.Join(runArtifactRoot, subdir), os.ModePerm)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// invoke
 	storage, err := NewLocal(nil)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	file, err := storage.Get(context.Background(), runArtifactRoot, "non-existent-file")
 	assert.NotNil(t, err)
@@ -87,15 +88,15 @@ func TestLocal_ListArtifacts_Ok(t *testing.T) {
 
 			// 1. create test artifacts.
 			err := os.WriteFile(filepath.Join(runArtifactDir, "artifact.file1"), []byte("contextX"), fs.ModePerm)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			err = os.Mkdir(filepath.Join(runArtifactDir, "artifact.dir"), fs.ModePerm)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.dir", "artifact.file2"), []byte("contentXX"), fs.ModePerm)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// 2. create storage.
 			storage, err := NewLocal(nil)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// 3. list artifacts for root dir.
 			rootDirResp, err := storage.List(context.Background(), runArtifactURI, "")
@@ -112,7 +113,7 @@ func TestLocal_ListArtifacts_Ok(t *testing.T) {
 					Size:  8,
 				},
 			}, rootDirResp)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// 4. list artifacts for sub dir.
 			subDirResp, err := storage.List(context.Background(), runArtifactURI, "artifact.dir")
@@ -122,12 +123,12 @@ func TestLocal_ListArtifacts_Ok(t *testing.T) {
 				IsDir: false,
 				Size:  9,
 			}, subDirResp[0])
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			// 5. list artifacts for non-existing dir.
 			nonExistingDirResp, err := storage.List(context.Background(), runArtifactURI, "non-existing-dir")
 			assert.Equal(t, 0, len(nonExistingDirResp))
-			assert.Nil(t, err)
+			require.Nil(t, err)
 		})
 	}
 }

--- a/pkg/api/mlflow/service/artifact/validators_test.go
+++ b/pkg/api/mlflow/service/artifact/validators_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -74,7 +75,7 @@ func TestValidateListArtifactsRequest_Ok(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Nil(t, ValidateListArtifactsRequest(tt.request))
+			require.Nil(t, ValidateListArtifactsRequest(tt.request))
 		})
 	}
 }
@@ -226,7 +227,7 @@ func TestValidateGetArtifactRequest_Ok(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Nil(t, ValidateGetArtifactRequest(tt.request))
+			require.Nil(t, ValidateGetArtifactRequest(tt.request))
 		})
 	}
 }

--- a/pkg/api/mlflow/service/experiment/service_test.go
+++ b/pkg/api/mlflow/service/experiment/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -51,7 +52,7 @@ func TestService_CreateExperiment_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "name", experiment.Name)
 	assert.Equal(t, []models.ExperimentTag{
 		{
@@ -244,7 +245,7 @@ func TestService_DeleteExperiment_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_DeleteExperiment_Error(t *testing.T) {
@@ -381,7 +382,7 @@ func TestService_GetExperiment_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, int32(1), *experiment.ID)
 	assert.Equal(t, "name", experiment.Name)
 	assert.Equal(t, []models.ExperimentTag{
@@ -517,7 +518,7 @@ func TestService_GetExperimentByName_Ok(t *testing.T) {
 	)
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, int32(1), *experiment.ID)
 	assert.Equal(t, "name", experiment.Name)
 	assert.Equal(t, []models.ExperimentTag{
@@ -644,7 +645,7 @@ func TestService_RestoreExperiment_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_RestoreExperiment_Error(t *testing.T) {
@@ -778,7 +779,7 @@ func TestService_SetExperimentTag_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_SetExperimentTag_Error(t *testing.T) {
@@ -930,7 +931,7 @@ func TestService_UpdateExperiment_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_UpdateExperiment_Error(t *testing.T) {

--- a/pkg/api/mlflow/service/experiment/validators_test.go
+++ b/pkg/api/mlflow/service/experiment/validators_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -14,7 +15,7 @@ func TestValidateCreateExperimentRequest_Ok(t *testing.T) {
 		Name:             "name",
 		ArtifactLocation: "location.com",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateCreateExperimentRequest_Error(t *testing.T) {
@@ -43,7 +44,7 @@ func TestValidateUpdateExperimentRequest_Ok(t *testing.T) {
 		ID:   "id",
 		Name: "name",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateUpdateExperimentRequest_Error(t *testing.T) {
@@ -78,7 +79,7 @@ func TestValidateGetExperimentByIDRequest_Ok(t *testing.T) {
 	err := ValidateGetExperimentByIDRequest(&request.GetExperimentRequest{
 		ID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateGetExperimentByIDRequest_Error(t *testing.T) {
@@ -113,7 +114,7 @@ func TestValidateGetExperimentByNameRequest_Ok(t *testing.T) {
 	err := ValidateGetExperimentByNameRequest(&request.GetExperimentRequest{
 		Name: "name",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateGetExperimentByNameRequest_Error(t *testing.T) {
@@ -141,7 +142,7 @@ func TestValidateDeleteExperimentRequest_Ok(t *testing.T) {
 	err := ValidateDeleteExperimentRequest(&request.DeleteExperimentRequest{
 		ID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateDeleteExperimentRequest_Error(t *testing.T) {
@@ -169,7 +170,7 @@ func TestValidateRestoreExperimentRequest_Ok(t *testing.T) {
 	err := ValidateRestoreExperimentRequest(&request.RestoreExperimentRequest{
 		ID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateRestoreExperimentRequest_Error(t *testing.T) {
@@ -198,7 +199,7 @@ func TestValidateSearchExperimentsRequest_Ok(t *testing.T) {
 		MaxResults: 10,
 		ViewType:   request.ViewTypeAll,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateSearchExperimentsRequest_Error(t *testing.T) {
@@ -237,7 +238,7 @@ func TestValidateSetExperimentTagRequest_Ok(t *testing.T) {
 		ID:  "id",
 		Key: "key",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateSetExperimentTagRequest_Error(t *testing.T) {

--- a/pkg/api/mlflow/service/metric/service_test.go
+++ b/pkg/api/mlflow/service/metric/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -57,7 +58,7 @@ func TestService_GetMetricHistory_Ok(t *testing.T) {
 	)
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, []models.Metric{
 		{
 			Key:       "key",
@@ -175,7 +176,7 @@ func TestService_GetMetricHistoryBulk_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, []models.Metric{
 		{
 			Key:       "key",
@@ -346,7 +347,7 @@ func TestNewService_GetMetricHistories_Ok(t *testing.T) {
 			rows, iterator, err := service.GetMetricHistories(context.TODO(), tt.namespace, tt.request)
 			assert.Equal(t, tt.expectedErr, err)
 			assert.Equal(t, tt.expectedRows, rows)
-			assert.Nil(t, rows.Err())
+			require.Nil(t, rows.Err())
 			assert.NotNil(t, iterator)
 		})
 	}

--- a/pkg/api/mlflow/service/metric/validators_test.go
+++ b/pkg/api/mlflow/service/metric/validators_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -15,7 +16,7 @@ func TestValidateGetMetricHistoryRequest_Ok(t *testing.T) {
 		RunUUID:   "uuid",
 		MetricKey: "key",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateGetMetricHistoryRequest_Error(t *testing.T) {
@@ -52,7 +53,7 @@ func TestValidateGetMetricHistoryBulkRequest_Ok(t *testing.T) {
 		MetricKey:  "key",
 		MaxResults: 10,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateGetMetricHistoryBulkRequest_Error(t *testing.T) {
@@ -98,7 +99,7 @@ func TestValidateGetMetricHistoriesRequest_Ok(t *testing.T) {
 		ViewType:   "",
 		MaxResults: 10,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateGetMetricHistoriesRequest_Error(t *testing.T) {

--- a/pkg/api/mlflow/service/run/service_test.go
+++ b/pkg/api/mlflow/service/run/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -81,7 +82,7 @@ func TestService_CreateRun_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.NotEmpty(t, run.ID)
 	assert.Equal(t, "name", run.Name)
 	assert.Equal(t, "1", run.UserID)
@@ -299,7 +300,7 @@ func TestService_RestoreRun_Ok(t *testing.T) {
 	err := service.RestoreRun(context.TODO(), &models.Namespace{ID: 1}, &request.RestoreRunRequest{RunID: "1"})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_RestoreRun_Error(t *testing.T) {
@@ -429,7 +430,7 @@ func TestService_SetRunTag_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 func TestService_SetRunTag_Error(t *testing.T) {}
 
@@ -459,7 +460,7 @@ func TestService_DeleteRun_Ok(t *testing.T) {
 	err := service.DeleteRun(context.TODO(), &models.Namespace{ID: 1}, &request.DeleteRunRequest{RunID: "1"})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_DeleteRun_Error(t *testing.T) {
@@ -798,7 +799,7 @@ func TestService_GetRun_Ok(t *testing.T) {
 	}, &request.GetRunRequest{RunID: "1"})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "1", run.ID)
 	assert.Equal(t, "name", run.Name)
 	assert.Equal(t, "source_type", run.SourceType)
@@ -980,7 +981,7 @@ func TestService_LogBatch_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_LogBatch_Error(t *testing.T) {
@@ -1379,7 +1380,7 @@ func TestService_LogMetric_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_LogMetric_Error(t *testing.T) {
@@ -1592,7 +1593,7 @@ func TestService_LogParam_Ok(t *testing.T) {
 	})
 
 	// compare results.
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestService_LogParam_Error(t *testing.T) {

--- a/pkg/api/mlflow/service/run/validators_test.go
+++ b/pkg/api/mlflow/service/run/validators_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
@@ -14,7 +15,7 @@ func TestValidateUpdateRunRequest_Ok(t *testing.T) {
 		RunID:   "id",
 		RunUUID: "uuid",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateUpdateRunRequest_Error(t *testing.T) {
@@ -42,7 +43,7 @@ func TestValidateGetRunRequest_Ok(t *testing.T) {
 	err := ValidateGetRunRequest(&request.GetRunRequest{
 		RunID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateGetRunRequest_Error(t *testing.T) {
@@ -70,7 +71,7 @@ func TestValidateDeleteRunRequest_Ok(t *testing.T) {
 	err := ValidateDeleteRunRequest(&request.DeleteRunRequest{
 		RunID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateDeleteRunRequest_Error(t *testing.T) {
@@ -98,7 +99,7 @@ func TestValidateRestoreRunRequest_Ok(t *testing.T) {
 	err := ValidateRestoreRunRequest(&request.RestoreRunRequest{
 		RunID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateRestoreRunRequest_Error(t *testing.T) {
@@ -129,7 +130,7 @@ func TestValidateLogMetricRequest_Ok(t *testing.T) {
 		Key:       "key",
 		Timestamp: 123,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateLogMetricRequest_Error(t *testing.T) {
@@ -174,7 +175,7 @@ func TestValidateLogParamRequest_Ok(t *testing.T) {
 		RunUUID: "uuid",
 		Key:     "key",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateLogParamRequest_Error(t *testing.T) {
@@ -211,7 +212,7 @@ func TestValidateSetRunTagRequest_Ok(t *testing.T) {
 		RunUUID: "uuid",
 		Key:     "key",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateSetRunTagRequest_Error(t *testing.T) {
@@ -246,7 +247,7 @@ func TestValidateDeleteRunTagRequest_Ok(t *testing.T) {
 	err := ValidateDeleteRunTagRequest(&request.DeleteRunTagRequest{
 		RunID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateDeleteRunTagRequest_Error(t *testing.T) {
@@ -274,7 +275,7 @@ func TestValidateLogBatchRequest_Ok(t *testing.T) {
 	err := ValidateLogBatchRequest(&request.LogBatchRequest{
 		RunID: "id",
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateLogBatchRequest_Error(t *testing.T) {
@@ -303,7 +304,7 @@ func TestValidateSearchRunsRequest_Ok(t *testing.T) {
 		ViewType:   request.ViewTypeAll,
 		MaxResults: 10,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestValidateSearchRunsRequest_Error(t *testing.T) {

--- a/pkg/database/db_factory_test.go
+++ b/pkg/database/db_factory_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeDBProvider(t *testing.T) {
@@ -28,13 +29,13 @@ func TestMakeDBProvider(t *testing.T) {
 				time.Second*2,
 				2,
 			)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			assert.NotNil(t, db)
 			assert.Equal(t, tt.expectedDialector, db.GormDB().Dialector.Name())
 
 			// expecting the global 'DB' not to be set
 			assert.Nil(t, DB)
-			assert.Nil(t, db.Close())
+			require.Nil(t, db.Close())
 		})
 	}
 }

--- a/tests/integration/golang/admin/namespace/create_test.go
+++ b/tests/integration/golang/admin/namespace/create_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -32,14 +33,14 @@ func (s *CreateNamespaceTestSuite) SetupTest() {
 
 func (s *CreateNamespaceTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	requests := []request.Namespace{
 		{
@@ -52,7 +53,7 @@ func (s *CreateNamespaceTestSuite) Test_Ok() {
 		},
 	}
 	for _, request := range requests {
-		assert.Nil(
+		require.Nil(
 			s.T(),
 			s.AdminClient.WithMethod(
 				http.MethodPost,
@@ -63,7 +64,7 @@ func (s *CreateNamespaceTestSuite) Test_Ok() {
 	}
 
 	namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.True(s.T(), helpers.CheckNamespaces(namespaces, requests))
 
 	// Check the length of the namespaces considering the default namespace
@@ -72,14 +73,14 @@ func (s *CreateNamespaceTestSuite) Test_Ok() {
 
 func (s *CreateNamespaceTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -130,7 +131,7 @@ func (s *CreateNamespaceTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			var resp goquery.Document
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AdminClient.WithMethod(
 					http.MethodPost,
@@ -147,7 +148,7 @@ func (s *CreateNamespaceTestSuite) Test_Error() {
 			assert.Equal(s.T(), tt.error, msg)
 
 			namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// Check that creation failed, only the default namespace is present
 			assert.Equal(s.T(), 1, len(namespaces))

--- a/tests/integration/golang/admin/namespace/delete_test.go
+++ b/tests/integration/golang/admin/namespace/delete_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -30,28 +31,28 @@ func (s *DeleteNamespaceTestSuite) SetupTest() {
 
 func (s *DeleteNamespaceTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	ns2, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  3,
 		Code:                "test3",
 		Description:         "test namespace 3 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name                   string
@@ -64,7 +65,7 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AdminClient.WithMethod(
 					http.MethodDelete,
@@ -73,7 +74,7 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 				),
 			)
 			namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedNamespaceCount, len(namespaces))
 		})
 	}
@@ -81,21 +82,21 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 
 func (s *DeleteNamespaceTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name                    string
@@ -116,7 +117,7 @@ func (s *DeleteNamespaceTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			var resp any
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AdminClient.WithMethod(
 					http.MethodDelete,
@@ -129,7 +130,7 @@ func (s *DeleteNamespaceTestSuite) Test_Error() {
 			assert.Equal(s.T(), resp, tt.response)
 		})
 		namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-		assert.Nil(s.T(), err)
+		require.Nil(s.T(), err)
 		// Check that deletion failed and the namespace is still there
 		assert.Equal(s.T(), tt.expectedNamespacesCount, len(namespaces))
 	}

--- a/tests/integration/golang/admin/namespace/update_test.go
+++ b/tests/integration/golang/admin/namespace/update_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -31,27 +32,27 @@ func (s *UpdateNamespaceTestSuite) SetupTest() {
 
 func (s *UpdateNamespaceTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	ns, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	request := request.Namespace{
 		Code:        "test2Updated",
 		Description: "test namespace 2 description updated",
 	}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.AdminClient.WithMethod(
 			http.MethodPut,
@@ -61,7 +62,7 @@ func (s *UpdateNamespaceTestSuite) Test_Ok() {
 	)
 
 	namespace, err := s.NamespaceFixtures.GetNamespaceByID(context.Background(), ns.ID)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	assert.Equal(s.T(), namespace.Code, request.Code)
 	assert.Equal(s.T(), namespace.Description, request.Description)
@@ -69,23 +70,23 @@ func (s *UpdateNamespaceTestSuite) Test_Ok() {
 
 func (s *UpdateNamespaceTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	expectedNamespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name     string
@@ -133,7 +134,7 @@ func (s *UpdateNamespaceTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			var resp any
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AdminClient.WithMethod(
 					http.MethodPut,
@@ -148,7 +149,7 @@ func (s *UpdateNamespaceTestSuite) Test_Error() {
 			assert.Equal(s.T(), resp, tt.response)
 		})
 		actualNamespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-		assert.Nil(s.T(), err)
+		require.Nil(s.T(), err)
 		assert.Equal(s.T(), expectedNamespaces, actualNamespaces)
 	}
 }

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -32,7 +33,7 @@ func (s *CreateAppTestSuite) SetupTest() {
 
 func (s *CreateAppTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +41,7 @@ func (s *CreateAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -59,7 +60,7 @@ func (s *CreateAppTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.App
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPost,
@@ -83,7 +84,7 @@ func (s *CreateAppTestSuite) Test_Ok() {
 
 func (s *CreateAppTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -91,7 +92,7 @@ func (s *CreateAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -107,7 +108,7 @@ func (s *CreateAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/aim/app/delete_app_test.go
+++ b/tests/integration/golang/aim/app/delete_app_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -34,7 +35,7 @@ func (s *DeleteAppTestSuite) SetupTest() {
 
 func (s *DeleteAppTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -42,7 +43,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -53,7 +54,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name             string
@@ -66,7 +67,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodDelete,
@@ -75,7 +76,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 				),
 			)
 			apps, err := s.AppFixtures.GetApps(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedAppCount, len(apps))
 		})
 	}
@@ -83,7 +84,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 
 func (s *DeleteAppTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -91,7 +92,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -102,7 +103,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name             string
@@ -118,7 +119,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodDelete,
@@ -131,7 +132,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 			assert.Contains(s.T(), resp.Message, "Not Found")
 
 			apps, err := s.AppFixtures.GetApps(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedAppCount, len(apps))
 		})
 	}

--- a/tests/integration/golang/aim/app/get_app_test.go
+++ b/tests/integration/golang/aim/app/get_app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -33,7 +34,7 @@ func (s *GetAppTestSuite) SetupTest() {
 
 func (s *GetAppTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -41,7 +42,7 @@ func (s *GetAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -52,10 +53,10 @@ func (s *GetAppTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp database.App
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/apps/%s", app.ID.String()))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/apps/%s", app.ID.String()))
 	assert.Equal(s.T(), app.ID, resp.ID)
 	assert.Equal(s.T(), app.Type, resp.Type)
 	assert.Equal(s.T(), app.State, resp.State)
@@ -65,7 +66,7 @@ func (s *GetAppTestSuite) Test_Ok() {
 
 func (s *GetAppTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -73,7 +74,7 @@ func (s *GetAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -87,7 +88,7 @@ func (s *GetAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/apps/%v", tt.idParam))
+			require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/apps/%v", tt.idParam))
 			assert.Equal(s.T(), "Not Found", resp.Message)
 		})
 	}

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -46,7 +47,7 @@ func (s *GetAppsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			defer func() {
-				assert.Nil(s.T(), s.AppFixtures.UnloadFixtures())
+				require.Nil(s.T(), s.AppFixtures.UnloadFixtures())
 			}()
 
 			namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -54,13 +55,13 @@ func (s *GetAppsTestSuite) Test_Ok() {
 				Code:                "default",
 				DefaultExperimentID: common.GetPointer(int32(0)),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			apps, err := s.AppFixtures.CreateApps(context.Background(), namespace, tt.expectedAppCount)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var resp []response.App
-			assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/apps"))
+			require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/apps"))
 			assert.Equal(s.T(), tt.expectedAppCount, len(resp))
 			for idx := 0; idx < tt.expectedAppCount; idx++ {
 				assert.Equal(s.T(), apps[idx].ID.String(), resp[idx].ID)

--- a/tests/integration/golang/aim/app/update_app_test.go
+++ b/tests/integration/golang/aim/app/update_app_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -35,7 +36,7 @@ func (s *UpdateAppTestSuite) SetupTest() {
 
 func (s *UpdateAppTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -43,7 +44,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -54,7 +55,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -73,7 +74,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.App
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,
@@ -85,7 +86,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 					"/apps/%s", app.ID,
 				),
 			)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,
@@ -105,7 +106,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 
 func (s *UpdateAppTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -113,7 +114,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -124,7 +125,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -150,7 +151,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -35,7 +36,7 @@ func (s *CreateDashboardTestSuite) SetupTest() {
 
 func (s *CreateDashboardTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -43,7 +44,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -55,7 +56,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -73,7 +74,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Dashboard
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPost,
@@ -85,7 +86,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 			)
 
 			dashboards, err := s.DashboardFixtures.GetDashboards(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.requestBody.Name, resp.Name)
 			assert.Equal(s.T(), tt.requestBody.Description, resp.Description)
 			assert.Equal(s.T(), dashboards[0].Name, resp.Name)
@@ -99,7 +100,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 
 func (s *CreateDashboardTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -107,7 +108,7 @@ func (s *CreateDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -125,7 +126,7 @@ func (s *CreateDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -34,7 +35,7 @@ func (s *DeleteDashboardTestSuite) SetupTest() {
 
 func (s *DeleteDashboardTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -42,7 +43,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -54,7 +55,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -66,7 +67,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name                   string
@@ -80,7 +81,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodDelete,
@@ -91,7 +92,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 				),
 			)
 			dashboards, err := s.DashboardFixtures.GetDashboards(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedDashboardCount, len(dashboards))
 		})
 	}
@@ -99,7 +100,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 
 func (s *DeleteDashboardTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -107,7 +108,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -119,7 +120,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -131,7 +132,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name                   string
@@ -147,7 +148,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodDelete,
@@ -160,7 +161,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 			assert.Contains(s.T(), resp.Message, "Not Found")
 
 			dashboards, err := s.DashboardFixtures.GetDashboards(context.Background())
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedDashboardCount, len(dashboards))
 		})
 	}

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -33,7 +34,7 @@ func (s *GetDashboardTestSuite) SetupTest() {
 
 func (s *GetDashboardTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -41,7 +42,7 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -53,7 +54,7 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -65,10 +66,10 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp database.Dashboard
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/dashboards/%s", dashboard.ID))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/dashboards/%s", dashboard.ID))
 	assert.Equal(s.T(), dashboard.ID, resp.ID)
 	assert.Equal(s.T(), &app.ID, resp.AppID)
 	assert.Equal(s.T(), dashboard.Name, resp.Name)
@@ -79,7 +80,7 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 
 func (s *GetDashboardTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -87,7 +88,7 @@ func (s *GetDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -101,7 +102,7 @@ func (s *GetDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithResponse(&resp).DoRequest("/dashboards/%s", tt.idParam),
 			)

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -48,7 +49,7 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			defer func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			}()
 
 			namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -56,7 +57,7 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 				Code:                "default",
 				DefaultExperimentID: common.GetPointer(int32(0)),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 				Base: database.Base{
@@ -68,15 +69,15 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 				State:       database.AppState{},
 				NamespaceID: namespace.ID,
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			dashboards, err := s.DashboardFixtures.CreateDashboards(
 				context.Background(), tt.expectedDashboardCount, &app.ID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var resp []response.Dashboard
-			assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/dashboards"))
+			require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/dashboards"))
 			assert.Equal(s.T(), tt.expectedDashboardCount, len(resp))
 			for idx := 0; idx < tt.expectedDashboardCount; idx++ {
 				assert.Equal(s.T(), dashboards[idx].ID.String(), resp[idx].ID)

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -35,7 +36,7 @@ func (s *UpdateDashboardTestSuite) SetupTest() {
 
 func (s *UpdateDashboardTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -43,7 +44,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -55,7 +56,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -67,7 +68,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -84,7 +85,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Dashboard
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,
@@ -96,7 +97,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 					"/dashboards/%s", dashboard.ID,
 				),
 			)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,
@@ -111,7 +112,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 
 			actualDashboard, err := s.DashboardFixtures.GetDashboardByID(context.Background(), dashboard.ID.String())
 
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.requestBody.Name, resp.Name)
 			assert.Equal(s.T(), tt.requestBody.Description, resp.Description)
 			assert.Equal(s.T(), (dashboard.ID).String(), resp.ID)
@@ -123,7 +124,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 
 func (s *UpdateDashboardTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -131,7 +132,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -143,7 +144,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -155,7 +156,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name        string
@@ -180,7 +181,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(s.T(), s.AIMClient.WithMethod(
+			require.Nil(s.T(), s.AIMClient.WithMethod(
 				http.MethodPut,
 			).WithRequest(
 				tt.requestBody,

--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -34,7 +35,7 @@ func (s *DeleteExperimentTestSuite) SetupTest() {
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -42,7 +43,7 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -64,14 +65,14 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiments, err := s.ExperimentFixtures.GetTestExperiments(context.Background())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	length := len(experiments)
 
 	var resp response.DeleteExperiment
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.AIMClient.WithMethod(
 			http.MethodDelete,
@@ -83,13 +84,13 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 	)
 
 	remainingExperiments, err := s.ExperimentFixtures.GetTestExperiments(context.Background())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), length-1, len(remainingExperiments))
 }
 
 func (s *DeleteExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -97,7 +98,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name  string
@@ -119,7 +120,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp api.ErrorResponse
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodDelete,

--- a/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -32,7 +33,7 @@ func (s *GetExperimentActivityTestSuite) SetupTest() {
 
 func (s *GetExperimentActivityTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,24 +41,24 @@ func (s *GetExperimentActivityTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	archivedRunsIds := []string{runs[0].ID, runs[1].ID}
 	err = s.RunFixtures.ArchiveRuns(context.Background(), archivedRunsIds)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp response.GetExperimentActivity
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%d/activity", *experiment.ID),
 	)
@@ -69,7 +70,7 @@ func (s *GetExperimentActivityTestSuite) Test_Ok() {
 
 func (s *GetExperimentActivityTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -77,7 +78,7 @@ func (s *GetExperimentActivityTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name  string
@@ -99,7 +100,7 @@ func (s *GetExperimentActivityTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp api.ErrorResponse
-			assert.Nil(s.T(), s.AIMClient.WithQuery(map[any]any{
+			require.Nil(s.T(), s.AIMClient.WithQuery(map[any]any{
 				"limit": 4,
 			}).WithResponse(&resp).DoRequest(
 				"/experiments/%s/activity", tt.ID,

--- a/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -32,7 +33,7 @@ func (s *GetExperimentRunsTestSuite) SetupTest() {
 
 func (s *GetExperimentRunsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,20 +41,20 @@ func (s *GetExperimentRunsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp response.GetExperimentRuns
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.AIMClient.WithQuery(map[any]any{
 			"limit":  4,
@@ -76,7 +77,7 @@ func (s *GetExperimentRunsTestSuite) Test_Ok() {
 
 func (s *GetExperimentRunsTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -84,7 +85,7 @@ func (s *GetExperimentRunsTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name  string
@@ -107,7 +108,7 @@ func (s *GetExperimentRunsTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			var resp api.ErrorResponse
-			assert.Nil(t, s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%s/runs", tt.ID))
+			require.Nil(t, s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%s/runs", tt.ID))
 			assert.Equal(s.T(), tt.error, resp.Error())
 		})
 	}

--- a/tests/integration/golang/aim/experiment/get_experiment_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -33,7 +34,7 @@ func (s *GetExperimentTestSuite) SetupTest() {
 
 func (s *GetExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -41,7 +42,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -63,10 +64,10 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp response.GetExperiment
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%d", *experiment.ID))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%d", *experiment.ID))
 
 	assert.Equal(s.T(), *experiment.ID, resp.ID)
 	assert.Equal(s.T(), experiment.Name, resp.Name)
@@ -78,7 +79,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 
 func (s *GetExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -86,7 +87,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name  string
@@ -109,7 +110,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			var resp api.ErrorResponse
-			assert.Nil(t, s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%s", tt.ID))
+			require.Nil(t, s.AIMClient.WithResponse(&resp).DoRequest("/experiments/%s", tt.ID))
 			assert.Equal(s.T(), tt.error, resp.Error())
 		})
 	}

--- a/tests/integration/golang/aim/experiment/get_experiments_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiments_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -33,7 +34,7 @@ func (s *GetExperimentsTestSuite) SetupTest() {
 
 func (s *GetExperimentsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -41,7 +42,7 @@ func (s *GetExperimentsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiments := map[int32]*models.Experiment{}
 	for i := 0; i < 5; i++ {
@@ -66,12 +67,12 @@ func (s *GetExperimentsTestSuite) Test_Ok() {
 			ArtifactLocation: "/artifact/location",
 		}
 		experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-		assert.Nil(s.T(), err)
+		require.Nil(s.T(), err)
 		experiments[*experiment.ID] = experiment
 	}
 
 	var resp response.Experiments
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/experiments/"))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/experiments/"))
 	assert.Equal(s.T(), len(experiments), len(resp))
 	for _, actualExperiment := range resp {
 		expectedExperiment := experiments[actualExperiment.ID]

--- a/tests/integration/golang/aim/metric/search_aligned_test.go
+++ b/tests/integration/golang/aim/metric/search_aligned_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -36,14 +37,14 @@ func (s *SearchAlignedMetricsTestSuite) SetupTest() {
 
 func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -51,14 +52,14 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create different test runs and attach, metrics.
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -79,7 +80,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -89,7 +90,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric1Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -99,7 +100,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -109,7 +110,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric2Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -119,7 +120,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -129,7 +130,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric3Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -139,7 +140,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
 		Name:       "TestRun2",
@@ -158,7 +159,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -168,7 +169,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric1Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -178,7 +179,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -188,7 +189,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric2Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -198,7 +199,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -208,7 +209,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric3Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -218,7 +219,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
 		Name:       "TestRun3",
@@ -237,7 +238,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -247,7 +248,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric1Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -257,7 +258,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -267,7 +268,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric2Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -277,7 +278,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     2.6,
@@ -287,7 +288,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric3Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     2.6,
@@ -297,7 +298,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	runs := []*models.Run{run1, run2, run3}
 
@@ -742,7 +743,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := new(bytes.Buffer)
-			assert.Nil(s.T(), s.AIMClient.WithMethod(
+			require.Nil(s.T(), s.AIMClient.WithMethod(
 				http.MethodPost,
 			).WithRequest(
 				tt.request,
@@ -755,7 +756,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 			))
 
 			decodedData, err := encoding.Decode(resp)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			xValues := make(map[int][]float64)
 

--- a/tests/integration/golang/aim/metric/search_test.go
+++ b/tests/integration/golang/aim/metric/search_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -35,7 +36,7 @@ func (s *SearchMetricsTestSuite) SetupTest() {
 
 func (s *SearchMetricsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -43,7 +44,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -51,14 +52,14 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create different test runs and attach tags, metrics, params, etc.
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -79,7 +80,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -89,7 +90,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric1Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -99,7 +100,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -109,7 +110,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      2,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric2Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -119,7 +120,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  2,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -129,7 +130,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric3Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -139,19 +140,19 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run1.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag1",
 		RunID: run1.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
@@ -171,7 +172,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -181,7 +182,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric1Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -191,7 +192,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -201,7 +202,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      2,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric2Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -211,7 +212,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  2,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -221,7 +222,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric3Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -231,19 +232,19 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param2",
 		Value: "value2",
 		RunID: run2.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag2",
 		RunID: run2.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
@@ -263,7 +264,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -273,7 +274,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric1Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -283,7 +284,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -293,7 +294,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      4,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	metric2Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -303,20 +304,20 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  4,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param3",
 		Value: "value3",
 		RunID: run3.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag3",
 		RunID: run3.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	runs := []*models.Run{run1, run2, run3}
 	tests := []struct {
@@ -5884,7 +5885,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := new(bytes.Buffer)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithQuery(
 					tt.request,
@@ -5895,7 +5896,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 				).DoRequest("/runs/search/metric"),
 			)
 			decodedData, err := encoding.Decode(resp)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var decodedMetrics []*models.LatestMetric
 			for _, run := range runs {

--- a/tests/integration/golang/aim/project/get_project_activity_test.go
+++ b/tests/integration/golang/aim/project/get_project_activity_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -31,7 +32,7 @@ func (s *GetProjectActivityTestSuite) SetupTest() {
 
 func (s *GetProjectActivityTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -39,24 +40,24 @@ func (s *GetProjectActivityTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	archivedRunsIds := []string{runs[0].ID, runs[1].ID}
 	err = s.RunFixtures.ArchiveRuns(context.Background(), archivedRunsIds)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp response.ProjectActivityResponse
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/projects/activity"))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/projects/activity"))
 
 	assert.Equal(s.T(), 8, resp.NumActiveRuns)
 	assert.Equal(s.T(), 2, resp.NumArchivedRuns)

--- a/tests/integration/golang/aim/project/get_project_params_test.go
+++ b/tests/integration/golang/aim/project/get_project_params_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -31,7 +32,7 @@ func (s *GetProjectParamsTestSuite) SetupTest() {
 
 func (s *GetProjectParamsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// 1. create test `namespace` and connect test `run`.
@@ -40,7 +41,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// 2. create test `experiment` and connect test `run`.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -48,7 +49,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "id",
@@ -58,7 +59,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// 3. create latest metric.
 	metric, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
@@ -70,7 +71,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		RunID:     run.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// 4. create test param and tag.
 	tag, err := s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -78,18 +79,18 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	param, err := s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// 5. check that response contains metric from previous step.
 	resp := response.ProjectParamsResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.AIMClient.WithQuery(
 			map[any]any{"sequence": "metric"},
@@ -114,11 +115,11 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 
 	// 6. mark run as `deleted`.
 	run.LifecycleStage = models.LifecycleStageDeleted
-	assert.Nil(s.T(), s.RunFixtures.UpdateRun(context.Background(), run))
+	require.Nil(s.T(), s.RunFixtures.UpdateRun(context.Background(), run))
 
 	// 7. check that endpoint returns an empty response.
 	resp = response.ProjectParamsResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.AIMClient.WithQuery(
 			map[any]any{"sequence": "metric"},
@@ -134,6 +135,6 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 
 func (s *GetProjectParamsTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 }

--- a/tests/integration/golang/aim/project/get_project_status_test.go
+++ b/tests/integration/golang/aim/project/get_project_status_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -29,7 +30,7 @@ func (s *GetProjectStatusTestSuite) SetupTest() {
 
 func (s *GetProjectStatusTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -37,9 +38,9 @@ func (s *GetProjectStatusTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp string
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/projects/status"))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/projects/status"))
 	assert.Equal(s.T(), "up-to-date", resp)
 }

--- a/tests/integration/golang/aim/project/get_project_test.go
+++ b/tests/integration/golang/aim/project/get_project_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -30,7 +31,7 @@ func (s *GetProjectTestSuite) SetupTest() {
 
 func (s *GetProjectTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,10 +39,10 @@ func (s *GetProjectTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	var resp response.GetProjectResponse
-	assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/projects"))
+	require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/projects"))
 	assert.Equal(s.T(), "FastTrackML", resp.Name)
 	// assert.Equal(s.T(), "", resp.Path)
 	assert.Equal(s.T(), "", resp.Description)

--- a/tests/integration/golang/aim/run/archive_batch_test.go
+++ b/tests/integration/golang/aim/run/archive_batch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -35,22 +36,22 @@ func (s *ArchiveBatchTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *ArchiveBatchTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	tests := []struct {
@@ -83,10 +84,10 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			resp := map[string]any{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(http.MethodPost).WithQuery(map[any]any{
 					"archive": tt.archiveParam,
@@ -101,7 +102,7 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 			assert.Equal(s.T(), map[string]interface{}{"status": "OK"}, resp)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), 10, len(runs))
 			archiveCount := 0
 			for _, run := range runs {
@@ -114,7 +115,7 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
 			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
 		})
@@ -123,7 +124,7 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 
 func (s *ArchiveBatchTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -141,10 +142,10 @@ func (s *ArchiveBatchTestSuite) Test_Error() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var resp fiber.Map
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(http.MethodPost).WithQuery(map[any]any{
 					"archive": true,
@@ -159,13 +160,13 @@ func (s *ArchiveBatchTestSuite) Test_Error() {
 			assert.Equal(s.T(), fiber.Map{"status": "OK"}, resp)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
 			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
 		})

--- a/tests/integration/golang/aim/run/delete_batch_test.go
+++ b/tests/integration/golang/aim/run/delete_batch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
@@ -36,22 +37,22 @@ func (s *DeleteBatchTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *DeleteBatchTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -74,10 +75,10 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			resp := fiber.Map{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(http.MethodPost).WithRequest(
 					tt.runIDs,
@@ -90,13 +91,13 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 			assert.Equal(s.T(), fiber.Map{"status": "OK"}, resp)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
 			assert.Greater(s.T(), originalMaxRowNum, newMaxRowNum)
 		})
@@ -105,7 +106,7 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 
 func (s *DeleteBatchTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -123,10 +124,10 @@ func (s *DeleteBatchTestSuite) Test_Error() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var resp api.ErrorResponse
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(http.MethodPost).WithRequest(
 					tt.request,
@@ -139,13 +140,13 @@ func (s *DeleteBatchTestSuite) Test_Error() {
 			assert.Contains(s.T(), resp.Error(), "count of deleted runs does not match length of ids input")
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
 			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
 		})

--- a/tests/integration/golang/aim/run/delete_test.go
+++ b/tests/integration/golang/aim/run/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
@@ -37,22 +38,22 @@ func (s *DeleteRunTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *DeleteRunTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -81,10 +82,10 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 				context.Background(),
 				s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var resp fiber.Map
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(http.MethodDelete).WithRequest(
 					tt.request,
@@ -96,13 +97,13 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 			)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
 			assert.Greater(s.T(), originalMaxRowNum, newMaxRowNum)
 		})
@@ -111,7 +112,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 
 func (s *DeleteRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name    string
@@ -127,10 +128,10 @@ func (s *DeleteRunTestSuite) Test_Error() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			var resp api.ErrorResponse
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(http.MethodDelete).WithRequest(
 					tt.request.RunID,
@@ -145,7 +146,7 @@ func (s *DeleteRunTestSuite) Test_Error() {
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
 			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
 		})

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -35,22 +36,22 @@ func (s *GetRunInfoTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *GetRunInfoTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name  string
@@ -64,7 +65,7 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.GetRunInfo
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID),
 			)
@@ -84,7 +85,7 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 
 func (s *GetRunInfoTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name  string
@@ -98,7 +99,7 @@ func (s *GetRunInfoTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID))
+			require.Nil(s.T(), s.AIMClient.WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID))
 			assert.Equal(s.T(), "Not Found", resp.Message)
 		})
 	}

--- a/tests/integration/golang/aim/run/get_run_metrics_test.go
+++ b/tests/integration/golang/aim/run/get_run_metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -36,22 +37,22 @@ func (s *GetRunMetricsTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *GetRunMetricsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -91,7 +92,7 @@ func (s *GetRunMetricsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.GetRunMetrics
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPost,
@@ -110,7 +111,7 @@ func (s *GetRunMetricsTestSuite) Test_Ok() {
 
 func (s *GetRunMetricsTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name  string
@@ -126,7 +127,7 @@ func (s *GetRunMetricsTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithResponse(&resp).DoRequest("/runs/%s/metric/get-batch", tt.runID),
 			)

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -34,7 +35,7 @@ func (s *GetRunsActiveTestSuite) SetupTest() {
 
 func (s *GetRunsActiveTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -42,7 +43,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name         string
@@ -62,10 +63,10 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 					NamespaceID:    namespace.ID,
 					LifecycleStage: models.LifecycleStageActive,
 				})
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 
 				s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 3)
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 			},
 		},
 		{
@@ -74,7 +75,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 			beforeRunFn: func() {
 				// set 3rd run to status = StatusFinished
 				s.runs[2].Status = models.StatusFinished
-				assert.Nil(s.T(), s.RunFixtures.UpdateRun(context.Background(), s.runs[2]))
+				require.Nil(s.T(), s.RunFixtures.UpdateRun(context.Background(), s.runs[2]))
 			},
 		},
 	}
@@ -84,7 +85,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 				tt.beforeRunFn()
 			}
 			resp := new(bytes.Buffer)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithResponseType(
 					helpers.ResponseTypeBuffer,
@@ -93,7 +94,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 				).DoRequest("/runs/active"),
 			)
 			decodedData, err := encoding.Decode(resp)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			responseCount := 0
 			for _, run := range s.runs {

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -36,7 +37,7 @@ func (s *SearchTestSuite) SetupTest() {
 
 func (s *SearchTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,7 +45,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -52,14 +53,14 @@ func (s *SearchTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create 3 different test runs and attach tags, metrics, params, etc.
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -81,13 +82,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag1",
 		RunID: run1.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     1.1,
@@ -97,13 +98,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run1.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
@@ -124,13 +125,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag2",
 		RunID: run2.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     2.1,
@@ -140,13 +141,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param2",
 		Value: "value2",
 		RunID: run2.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
@@ -167,13 +168,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag3",
 		RunID: run3.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     3.1,
@@ -183,13 +184,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  3,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param3",
 		Value: "value3",
 		RunID: run3.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run4, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id4",
@@ -210,13 +211,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri4",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag4",
 		RunID: run4.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     4.1,
@@ -226,13 +227,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run4.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param4",
 		Value: "value4",
 		RunID: run4.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	runs := []*models.Run{run1, run2, run3, run4}
 
@@ -778,7 +779,7 @@ func (s *SearchTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := new(bytes.Buffer)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithResponseType(
 					helpers.ResponseTypeBuffer,
@@ -790,7 +791,7 @@ func (s *SearchTestSuite) Test_Ok() {
 			)
 
 			decodedData, err := encoding.Decode(resp)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			for _, run := range runs {
 				respNameKey := fmt.Sprintf("%v.props.name", run.ID)

--- a/tests/integration/golang/aim/run/update_run_test.go
+++ b/tests/integration/golang/aim/run/update_run_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -36,22 +37,22 @@ func (s *UpdateRunTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *UpdateRunTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name    string
@@ -70,7 +71,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Success
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,
@@ -83,7 +84,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 				),
 			)
 			run, err := s.RunFixtures.GetRun(context.Background(), s.run.ID)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			// TODO the PUT endpoint only updates LifecycleStage
 			// assert.Equal(t, newName, run.Name)
 			// assert.Equal(t, models.Status(newStatus), run.Status)
@@ -94,7 +95,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 
 func (s *UpdateRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name        string
@@ -120,7 +121,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			var resp response.Error
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.AIMClient.WithMethod(
 					http.MethodPut,

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gorm.io/gorm"
 
@@ -36,7 +36,7 @@ func (s *BaseTestSuite) SetupTest(t *testing.T) {
 			1*time.Second,
 			20,
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		db = instance.GormDB()
 	}
 
@@ -45,41 +45,41 @@ func (s *BaseTestSuite) SetupTest(t *testing.T) {
 	s.AdminClient = NewAdminApiClient(GetServiceUri())
 
 	appFixtures, err := fixtures.NewAppFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.AppFixtures = appFixtures
 
 	dashboardFixtures, err := fixtures.NewDashboardFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.DashboardFixtures = dashboardFixtures
 
 	experimentFixtures, err := fixtures.NewExperimentFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.ExperimentFixtures = experimentFixtures
 
 	metricFixtures, err := fixtures.NewMetricFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.MetricFixtures = metricFixtures
 
 	namespaceFixtures, err := fixtures.NewNamespaceFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.NamespaceFixtures = namespaceFixtures
 
 	projectFixtures, err := fixtures.NewProjectFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.ProjectFixtures = projectFixtures
 
 	paramFixtures, err := fixtures.NewParamFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.ParamFixtures = paramFixtures
 
 	runFixtures, err := fixtures.NewRunFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.RunFixtures = runFixtures
 
 	tagFixtures, err := fixtures.NewTagFixtures(db)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	s.TagFixtures = tagFixtures
 
 	// by default, unload everything.
-	assert.Nil(t, s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(t, s.NamespaceFixtures.UnloadFixtures())
 }

--- a/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -39,7 +40,7 @@ func (s *GetArtifactLocalTestSuite) SetupTest() {
 
 func (s *GetArtifactLocalTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -47,7 +48,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name   string
@@ -73,7 +74,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("%s%s", tt.prefix, experimentArtifactDir),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -86,17 +87,17 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s%s", tt.prefix, runArtifactDir),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 3. create artifacts.
 			err = os.MkdirAll(runArtifactDir, fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.file1"), []byte("contentX"), fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			err = os.Mkdir(filepath.Join(runArtifactDir, "artifact.dir"), fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.dir", "artifact.file2"), []byte("contentXX"), fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 4. make actual API call for root dir file
 			rootFileQuery := request.GetArtifactRequest{
@@ -105,7 +106,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			resp := new(bytes.Buffer)
-			assert.Nil(s.T(), s.MlflowClient.WithQuery(
+			require.Nil(s.T(), s.MlflowClient.WithQuery(
 				rootFileQuery,
 			).WithResponseType(
 				helpers.ResponseTypeBuffer,
@@ -123,7 +124,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			resp = new(bytes.Buffer)
-			assert.Nil(s.T(), s.MlflowClient.WithQuery(
+			require.Nil(s.T(), s.MlflowClient.WithQuery(
 				subDirQuery,
 			).WithResponseType(
 				helpers.ResponseTypeBuffer,
@@ -139,7 +140,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 
 func (s *GetArtifactLocalTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -147,7 +148,7 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test experiment
 	experimentArtifactDir := s.T().TempDir()
@@ -157,7 +158,7 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: experimentArtifactDir,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run
 	runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -170,10 +171,10 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 		ArtifactURI:    runArtifactDir,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	err = os.MkdirAll(filepath.Join(runArtifactDir, "subdir"), fs.ModePerm)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -258,7 +259,7 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(t, s.MlflowClient.WithQuery(
+			require.Nil(t, s.MlflowClient.WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -40,22 +41,22 @@ func (s *GetArtifactS3TestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest(s.T())
 
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	err = helpers.CreateS3Buckets(s3Client, s.testBuckets)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.s3Client = s3Client
 }
 
 func (s *GetArtifactS3TestSuite) TearDownTest() {
 	err := helpers.RemoveS3Buckets(s.s3Client, s.testBuckets)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *GetArtifactS3TestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -63,7 +64,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name   string
@@ -88,7 +89,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("s3://%s/1", tt.bucket),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// create test run
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -100,7 +101,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s/%s/artifacts", experiment.ArtifactLocation, runID),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// upload artifact root object to S3
 			putObjReq := &s3.PutObjectInput{
@@ -109,7 +110,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 				Bucket: aws.String(tt.bucket),
 			}
 			_, err = s.s3Client.PutObject(context.Background(), putObjReq)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// upload artifact subdir object to S3
 			putObjReq = &s3.PutObjectInput{
@@ -121,7 +122,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 				Bucket: aws.String(tt.bucket),
 			}
 			_, err = s.s3Client.PutObject(context.Background(), putObjReq)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// make API call for root object
 			query := request.GetArtifactRequest{
@@ -130,7 +131,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 			}
 
 			resp := new(bytes.Buffer)
-			assert.Nil(s.T(), s.MlflowClient.WithQuery(
+			require.Nil(s.T(), s.MlflowClient.WithQuery(
 				query,
 			).WithResponseType(
 				helpers.ResponseTypeBuffer,
@@ -148,7 +149,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 			}
 
 			resp = new(bytes.Buffer)
-			assert.Nil(s.T(), s.MlflowClient.WithQuery(
+			require.Nil(s.T(), s.MlflowClient.WithQuery(
 				query,
 			).WithResponseType(
 				helpers.ResponseTypeBuffer,
@@ -164,7 +165,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 
 func (s *GetArtifactS3TestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -172,7 +173,7 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test experiment
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -181,7 +182,7 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "s3://bucket1/1",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run
 	runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -193,7 +194,7 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 		ArtifactURI:    fmt.Sprintf("%s/%s/artifacts", experiment.ArtifactLocation, runID),
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// upload artifact subdir object to S3
 	putObjReq := &s3.PutObjectInput{
@@ -202,7 +203,7 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 		Bucket: aws.String("bucket1"),
 	}
 	_, err = s.s3Client.PutObject(context.Background(), putObjReq)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -279,7 +280,7 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(t, s.MlflowClient.WithQuery(
+			require.Nil(t, s.MlflowClient.WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,

--- a/tests/integration/golang/mlflow/artifact/list_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_gs_test.go
@@ -13,6 +13,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -41,21 +42,21 @@ func (s *ListArtifactGSTestSuite) SetupSuite() {
 	s.BaseTestSuite.SetupTest(s.T())
 
 	gsClient, err := helpers.NewGSClient(helpers.GetGSEndpointUri())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	s.gsClient = gsClient
 }
 
 func (s *ListArtifactGSTestSuite) SetupTest() {
-	assert.Nil(s.T(), helpers.CreateGSBuckets(s.gsClient, s.testBuckets))
+	require.Nil(s.T(), helpers.CreateGSBuckets(s.gsClient, s.testBuckets))
 }
 
 func (s *ListArtifactGSTestSuite) TearDownTest() {
-	assert.Nil(s.T(), helpers.DeleteGSBuckets(s.gsClient, s.testBuckets))
+	require.Nil(s.T(), helpers.DeleteGSBuckets(s.gsClient, s.testBuckets))
 }
 
 func (s *ListArtifactGSTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -63,7 +64,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name   string
@@ -102,7 +103,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("gs://%s/1", tt.bucket),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -114,7 +115,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s/%s/artifacts", experiment.ArtifactLocation, runID),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 3. upload artifact objects to GS.
 			writer := s.gsClient.Bucket(
@@ -125,8 +126,8 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 				context.Background(),
 			)
 			_, err = writer.Write([]byte("contentX"))
-			assert.Nil(s.T(), err)
-			assert.Nil(t, writer.Close())
+			require.Nil(s.T(), err)
+			require.Nil(t, writer.Close())
 
 			writer = s.gsClient.Bucket(
 				tt.bucket,
@@ -136,8 +137,8 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 				context.Background(),
 			)
 			_, err = writer.Write([]byte("contentXX"))
-			assert.Nil(s.T(), err)
-			assert.Nil(t, writer.Close())
+			require.Nil(s.T(), err)
+			require.Nil(t, writer.Close())
 
 			// 4. make actual API call for root dir.
 			rootDirQuery := request.ListArtifactsRequest{
@@ -145,7 +146,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			}
 
 			rootDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					rootDirQuery,
@@ -170,7 +171,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 					FileSize: 8,
 				},
 			}, rootDirResp.Files)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 5. make actual API call for sub dir.
 			subDirQuery := request.ListArtifactsRequest{
@@ -179,7 +180,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			}
 
 			subDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					subDirQuery,
@@ -197,17 +198,17 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 				IsDir:    false,
 				FileSize: 9,
 			}, subDirResp.Files[0])
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 6. make actual API call for non-existing dir.
 			nonExistingDirQuery := request.ListArtifactsRequest{
 				RunID: run.ID,
 				Path:  "non-existing-dir",
 			}
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			nonExistingDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					nonExistingDirQuery,
@@ -220,14 +221,14 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 
 			assert.Equal(s.T(), run.ArtifactURI, nonExistingDirResp.RootURI)
 			assert.Equal(s.T(), 0, len(nonExistingDirResp.Files))
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 		})
 	}
 }
 
 func (s *ListArtifactGSTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -235,7 +236,7 @@ func (s *ListArtifactGSTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -292,7 +293,7 @@ func (s *ListArtifactGSTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,
@@ -302,7 +303,7 @@ func (s *ListArtifactGSTestSuite) Test_Error() {
 					fmt.Sprintf("%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsListRoute),
 				),
 			)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			assert.Equal(s.T(), tt.error.Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/artifact/list_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_local_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -41,7 +42,7 @@ func (s *ListArtifactLocalTestSuite) SetupTest() {
 
 func (s *ListArtifactLocalTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -49,7 +50,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name   string
@@ -89,7 +90,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("%s%s", tt.prefix, experimentArtifactDir),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -102,19 +103,19 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s%s", tt.prefix, runArtifactDir),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 3. create artifacts.
 			err = os.MkdirAll(runArtifactDir, fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.file1"), []byte("contentX"), fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			err = os.Mkdir(filepath.Join(runArtifactDir, "artifact.dir"), fs.ModePerm)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			err = os.WriteFile(
 				filepath.Join(runArtifactDir, "artifact.dir", "artifact.file2"), []byte("contentXX"), fs.ModePerm,
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 4. make actual API call for root dir.
 			rootDirQuery := request.ListArtifactsRequest{
@@ -122,7 +123,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			rootDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					rootDirQuery,
@@ -147,7 +148,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 					FileSize: 8,
 				},
 			}, rootDirResp.Files)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 5. make actual API call for sub dir.
 			subDirQuery := request.ListArtifactsRequest{
@@ -156,7 +157,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			subDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					subDirQuery,
@@ -174,7 +175,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				IsDir:    false,
 				FileSize: 9,
 			}, subDirResp.Files[0])
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 6. make actual API call for non-existing dir.
 			nonExistingDirQuery := request.ListArtifactsRequest{
@@ -183,7 +184,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			nonExistingDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					nonExistingDirQuery,
@@ -196,14 +197,14 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 
 			assert.Equal(s.T(), run.ArtifactURI, nonExistingDirResp.RootURI)
 			assert.Equal(s.T(), 0, len(nonExistingDirResp.Files))
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 		})
 	}
 }
 
 func (s *ListArtifactLocalTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -211,7 +212,7 @@ func (s *ListArtifactLocalTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -268,7 +269,7 @@ func (s *ListArtifactLocalTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(s.T(), s.MlflowClient.WithQuery(
+			require.Nil(s.T(), s.MlflowClient.WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -42,22 +43,22 @@ func (s *ListArtifactS3TestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest(s.T())
 
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	err = helpers.CreateS3Buckets(s3Client, s.testBuckets)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.s3Client = s3Client
 }
 
 func (s *ListArtifactS3TestSuite) TearDownTest() {
 	err := helpers.RemoveS3Buckets(s.s3Client, s.testBuckets)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 }
 
 func (s *ListArtifactS3TestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -65,7 +66,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name   string
@@ -104,7 +105,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("s3://%s/1", tt.bucket),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -116,7 +117,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s/%s/artifacts", experiment.ArtifactLocation, runID),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 3. upload artifact objects to S3.
 			_, err = s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
@@ -124,13 +125,13 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				Body:   strings.NewReader("contentX"),
 				Bucket: aws.String(tt.bucket),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			_, err = s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
 				Key:    aws.String(fmt.Sprintf("1/%s/artifacts/artifact.dir/artifact.file2", runID)),
 				Body:   strings.NewReader("contentXX"),
 				Bucket: aws.String(tt.bucket),
 			})
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 4. make actual API call for root dir.
 			rootDirQuery := request.ListArtifactsRequest{
@@ -138,7 +139,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 			}
 
 			rootDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					rootDirQuery,
@@ -163,7 +164,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 					FileSize: 8,
 				},
 			}, rootDirResp.Files)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 5. make actual API call for sub dir.
 			subDirQuery := request.ListArtifactsRequest{
@@ -172,7 +173,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 			}
 
 			subDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					subDirQuery,
@@ -190,17 +191,17 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				IsDir:    false,
 				FileSize: 9,
 			}, subDirResp.Files[0])
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 6. make actual API call for non-existing dir.
 			nonExistingDirQuery := request.ListArtifactsRequest{
 				RunID: run.ID,
 				Path:  "non-existing-dir",
 			}
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			nonExistingDirResp := response.ListArtifactsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					nonExistingDirQuery,
@@ -213,14 +214,14 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 
 			assert.Equal(s.T(), run.ArtifactURI, nonExistingDirResp.RootURI)
 			assert.Equal(s.T(), 0, len(nonExistingDirResp.Files))
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 		})
 	}
 }
 
 func (s *ListArtifactS3TestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -228,7 +229,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -285,7 +286,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,
@@ -295,7 +296,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 					fmt.Sprintf("%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsListRoute),
 				),
 			)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			assert.Equal(s.T(), tt.error.Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/experiment/create_test.go
+++ b/tests/integration/golang/mlflow/experiment/create_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -35,7 +36,7 @@ func (s *CreateExperimentTestSuite) SetupTest() {
 
 func (s *CreateExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -43,7 +44,7 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.CreateExperimentRequest{
 		Name:             "ExperimentName",
@@ -60,7 +61,7 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 		},
 	}
 	resp := response.CreateExperimentResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -77,7 +78,7 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 
 func (s *CreateExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -85,7 +86,7 @@ func (s *CreateExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -113,7 +114,7 @@ func (s *CreateExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/experiment/delete_test.go
+++ b/tests/integration/golang/mlflow/experiment/delete_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -37,7 +38,7 @@ func (s *DeleteExperimentTestSuite) SetupTest() {
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -45,7 +46,7 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -67,7 +68,7 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// check that the experiment lifecycle is active
 	assert.Equal(s.T(), models.LifecycleStageActive, experiment.LifecycleStage)
@@ -77,7 +78,7 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		ID: fmt.Sprintf("%d", *experiment.ID),
 	}
 	resp := fiber.Map{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -94,13 +95,13 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), models.LifecycleStageDeleted, exp.LifecycleStage)
 }
 
 func (s *DeleteExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -108,7 +109,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -145,7 +146,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/experiment/get_by_name_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_by_name_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *GetExperimentByNameTestSuite) SetupTest() {
 
 func (s *GetExperimentByNameTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,7 +45,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -66,7 +67,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// 2. make actual API call.
 	request := request.GetExperimentRequest{
@@ -74,7 +75,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetExperimentResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithQuery(
 			request,
@@ -101,7 +102,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 
 func (s *GetExperimentByNameTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -109,7 +110,7 @@ func (s *GetExperimentByNameTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -135,7 +136,7 @@ func (s *GetExperimentByNameTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,

--- a/tests/integration/golang/mlflow/experiment/get_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *GetExperimentTestSuite) SetupTest() {
 
 func (s *GetExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// 1. prepare database with test data.
@@ -45,7 +46,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -67,7 +68,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// 2. make actual API call.
 	request := request.GetExperimentRequest{
@@ -75,7 +76,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetExperimentResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithQuery(
 			request,
@@ -101,7 +102,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 
 func (s *GetExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -109,7 +110,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -140,7 +141,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,

--- a/tests/integration/golang/mlflow/experiment/restore_test.go
+++ b/tests/integration/golang/mlflow/experiment/restore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -37,7 +38,7 @@ func (s *RestoreExperimentTestSuite) SetupTest() {
 
 func (s *RestoreExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -45,7 +46,7 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -67,7 +68,7 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageDeleted,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), models.LifecycleStageDeleted, experiment.LifecycleStage)
 
 	// 2. make actual API call.
@@ -75,7 +76,7 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 		ID: fmt.Sprintf("%d", *experiment.ID),
 	}
 	resp := fiber.Map{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -92,13 +93,13 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), models.LifecycleStageActive, exp.LifecycleStage)
 }
 
 func (s *RestoreExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -106,7 +107,7 @@ func (s *RestoreExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -143,7 +144,7 @@ func (s *RestoreExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/experiment/search_test.go
+++ b/tests/integration/golang/mlflow/experiment/search_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *SearchExperimentsTestSuite) SetupTest() {
 
 func (s *SearchExperimentsTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,7 +45,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiments := []models.Experiment{
 		{
@@ -115,7 +116,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 			LifecycleStage:   ex.LifecycleStage,
 			ArtifactLocation: "/artifact/location",
 		})
-		assert.Nil(s.T(), err)
+		require.Nil(s.T(), err)
 	}
 
 	tests := []struct {
@@ -168,7 +169,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := response.SearchExperimentsResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,
@@ -191,7 +192,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 
 func (s *SearchExperimentsTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -199,7 +200,7 @@ func (s *SearchExperimentsTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -279,7 +280,7 @@ func (s *SearchExperimentsTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,

--- a/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
+++ b/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *SetExperimentTagTestSuite) SetupTest() {
 
 func (s *SetExperimentTagTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,7 +45,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:        "Test Experiment",
@@ -60,7 +61,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:        "Test Experiment2",
 		NamespaceID: namespace.ID,
@@ -75,7 +76,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// Set tag on experiment1
 	req := request.SetExperimentTagRequest{
@@ -83,7 +84,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Key:   "KeyTag1",
 		Value: "ValueTag1",
 	}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -97,7 +98,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment1, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment1.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.True(s.T(), helpers.CheckTagExists(
 		experiment1.Tags, "KeyTag1", "ValueTag1"), "Expected 'experiment.tags' to contain 'KeyTag1' with value 'ValueTag1'",
 	)
@@ -108,7 +109,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Key:   "KeyTag1",
 		Value: "ValueTag2",
 	}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -122,7 +123,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment1, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment1.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.True(
 		s.T(),
 		helpers.CheckTagExists(experiment1.Tags, "KeyTag1", "ValueTag2"),
@@ -133,7 +134,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment2, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment2.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), len(experiment2.Tags), 0)
 
 	// test that setting a tag on different experiments maintain different values across experiments
@@ -142,7 +143,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Key:   "KeyTag1",
 		Value: "ValueTag3",
 	}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -155,7 +156,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment1, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment1.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.True(
 		s.T(), helpers.CheckTagExists(experiment1.Tags, "KeyTag1", "ValueTag2"),
 		"Expected 'experiment1.tags' to contain 'KeyTag1' with value 'ValueTag2'",
@@ -164,7 +165,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment2, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment2.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.True(
 		s.T(),
 		helpers.CheckTagExists(experiment2.Tags, "KeyTag1", "ValueTag3"),
@@ -174,7 +175,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 
 func (s *SetExperimentTagTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -182,7 +183,7 @@ func (s *SetExperimentTagTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -230,7 +231,7 @@ func (s *SetExperimentTagTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/experiment/update_test.go
+++ b/tests/integration/golang/mlflow/experiment/update_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *UpdateExperimentTestSuite) SetupTest() {
 
 func (s *UpdateExperimentTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,7 +45,7 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:        "Test Experiment",
@@ -60,13 +61,13 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.UpdateExperimentRequest{
 		ID:   fmt.Sprintf("%d", *experiment.ID),
 		Name: "Test Updated Experiment",
 	}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -82,13 +83,13 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment.ID,
 	)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), "Test Updated Experiment", exp.Name)
 }
 
 func (s *UpdateExperimentTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -96,7 +97,7 @@ func (s *UpdateExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -133,7 +134,7 @@ func (s *UpdateExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,14 +37,14 @@ func (s *GetHistoriesTestSuite) SetupTest() {
 
 func (s *GetHistoriesTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment",
@@ -51,7 +52,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run1",
@@ -61,7 +62,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -72,7 +73,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run2",
@@ -82,7 +83,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -93,7 +94,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -115,7 +116,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := new(bytes.Buffer)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -143,7 +144,7 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -181,7 +182,7 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -193,7 +194,7 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 					fmt.Sprintf("%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoriesRoute),
 				),
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.error.Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -35,14 +36,14 @@ func (s *GetHistoriesBulkTestSuite) SetupTest() {
 
 func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment",
@@ -50,7 +51,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run1",
@@ -60,7 +61,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -71,7 +72,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run2",
@@ -81,7 +82,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -92,7 +93,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.GetMetricHistoryBulkRequest{
 		RunIDs:    []string{run1.ID, run2.ID},
@@ -100,7 +101,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetMetricHistoryResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithQuery(
 			req,
@@ -137,7 +138,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -169,7 +170,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -34,14 +35,14 @@ func (s *GetHistoryTestSuite) SetupTest() {
 
 func (s *GetHistoryTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment",
@@ -49,7 +50,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "id",
@@ -59,7 +60,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -70,7 +71,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.GetMetricHistoryRequest{
 		RunID:     run.ID,
@@ -78,7 +79,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetMetricHistoryResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithQuery(
 			req,
@@ -106,7 +107,7 @@ func (s *GetHistoryTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -129,7 +130,7 @@ func (s *GetHistoryTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *CreateRunTestSuite) SetupTest() {
 
 func (s *CreateRunTestSuite) Test_DefaultNamespace_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -45,21 +46,21 @@ func (s *CreateRunTestSuite) Test_DefaultNamespace_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.successCases(namespace, experiment, false, *experiment.ID)
 }
 
 func (s *CreateRunTestSuite) Test_DefaultNamespaceExperimentZero_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -68,26 +69,26 @@ func (s *CreateRunTestSuite) Test_DefaultNamespaceExperimentZero_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// update default experiment id for namespace.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.successCases(namespace, experiment, false, int32(0))
 }
 
 func (s *CreateRunTestSuite) Test_CustomNamespace_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -96,21 +97,21 @@ func (s *CreateRunTestSuite) Test_CustomNamespace_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.successCases(namespace, experiment, true, *experiment.ID)
 }
 
 func (s *CreateRunTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -119,19 +120,19 @@ func (s *CreateRunTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// update default experiment id.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.successCases(namespace, experiment, true, int32(0))
 }
@@ -171,7 +172,7 @@ func (s *CreateRunTestSuite) successCases(
 			namespace.Code,
 		)
 	}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		client.DoRequest(
 			fmt.Sprintf("%s%s", mlflow.RunsRoutePrefix, mlflow.RunsCreateRoute),
@@ -204,19 +205,19 @@ func (s *CreateRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// set namespace default experiment.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	nonExistingExperimentID := *experiment.ID + 1
 
 	tests := []struct {
@@ -284,7 +285,7 @@ func (s *CreateRunTestSuite) Test_Error() {
 			).WithResponse(
 				&resp,
 			)
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				client.DoRequest(
 					fmt.Sprintf("%s%s", mlflow.RunsRoutePrefix, mlflow.RunsCreateRoute),

--- a/tests/integration/golang/mlflow/run/delete_tag_test.go
+++ b/tests/integration/golang/mlflow/run/delete_tag_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -38,7 +39,7 @@ func (s *DeleteRunTagTestSuite) SetupTest() {
 
 func (s *DeleteRunTagTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -47,14 +48,14 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -74,7 +75,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create few tags,.
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -82,13 +83,13 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "tag2",
 		Value: "value2",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// make actual call to API.
 	query := request.GetRunRequest{
@@ -99,7 +100,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		Key:   "tag1",
 	}
 	resp := fiber.Map{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -117,7 +118,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 
 	// make sure that we still have one tag connected to Run.
 	tags, err := s.TagFixtures.GetByRunID(context.Background(), run.ID)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), 1, len(tags))
 	assert.Equal(s.T(), []models.Tag{
 		{
@@ -130,7 +131,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 
 func (s *DeleteRunTagTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -138,7 +139,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test experiment.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -146,7 +147,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -166,7 +167,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -201,7 +202,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/run/delete_test.go
+++ b/tests/integration/golang/mlflow/run/delete_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *DeleteRunTestSuite) SetupTest() {
 
 func (s *DeleteRunTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create experiment
@@ -45,14 +46,14 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -63,7 +64,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -77,7 +78,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := map[string]any{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -93,7 +94,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 
 			archivedRuns, err := s.RunFixtures.GetRuns(context.Background(), run.ExperimentID)
 
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(T, 1, len(archivedRuns))
 			assert.Equal(s.T(), run.ID, archivedRuns[0].ID)
 			assert.Equal(s.T(), models.LifecycleStageDeleted, archivedRuns[0].LifecycleStage)
@@ -107,7 +108,7 @@ func (s *DeleteRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -121,7 +122,7 @@ func (s *DeleteRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -133,7 +134,7 @@ func (s *DeleteRunTestSuite) Test_Error() {
 					fmt.Sprintf("%s%s", mlflow.RunsRoutePrefix, mlflow.RunsDeleteRoute),
 				),
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), api.NewResourceDoesNotExistError("unable to find run 'not-an-id'").Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -37,7 +38,7 @@ func (s *GetRunTestSuite) SetupTest() {
 
 func (s *GetRunTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -46,14 +47,14 @@ func (s *GetRunTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -73,7 +74,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create tags, metrics, params.
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -81,7 +82,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "metric1",
@@ -91,21 +92,21 @@ func (s *GetRunTestSuite) Test_Ok() {
 		Step:      1,
 		IsNan:     false,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	query := request.GetRunRequest{
 		RunID: run.ID,
 	}
 
 	resp := response.GetRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithQuery(
 			query,
@@ -153,7 +154,7 @@ func (s *GetRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -178,7 +179,7 @@ func (s *GetRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithQuery(
 					tt.request,
@@ -188,7 +189,7 @@ func (s *GetRunTestSuite) Test_Error() {
 					fmt.Sprintf("%s%s", mlflow.RunsRoutePrefix, mlflow.RunsGetRoute),
 				),
 			)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.error.Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *LogBatchTestSuite) SetupTest() {
 
 func (s *LogBatchTestSuite) TestTags_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,14 +45,14 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -60,7 +61,7 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -82,7 +83,7 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := map[string]any{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -101,7 +102,7 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 
 func (s *LogBatchTestSuite) TestParams_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -109,14 +110,14 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -125,7 +126,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -163,7 +164,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := map[string]any{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -182,7 +183,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 
 func (s *LogBatchTestSuite) TestMetrics_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -190,14 +191,14 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -206,7 +207,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name                  string
@@ -335,7 +336,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		s.T().Run(tt.name, func(T *testing.T) {
 			// do actual call to API.
 			resp := map[string]any{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,
@@ -352,7 +353,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 			// make sure that `iter` and `last_iter` for each metric has been updated correctly.
 			for key, iteration := range tt.latestMetricIteration {
 				lastMetric, err := s.MetricFixtures.GetLatestMetricByKey(context.Background(), key)
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 				assert.Equal(s.T(), iteration, lastMetric.LastIter)
 			}
 		})
@@ -361,7 +362,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 
 func (s *LogBatchTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -369,14 +370,14 @@ func (s *LogBatchTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -385,7 +386,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	testData := []struct {
 		name    string
@@ -419,7 +420,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.T().Run(tt.name, func(t *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -37,7 +38,7 @@ func (s *LogMetricTestSuite) SetupTest() {
 
 func (s *LogMetricTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -45,7 +46,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment := &models.Experiment{
 		Name:           uuid.New().String(),
@@ -53,7 +54,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 	}
 	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run := &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -63,7 +64,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		Status:         models.StatusRunning,
 	}
 	run, err = s.RunFixtures.CreateRun(context.Background(), run)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.LogMetricRequest{
 		RunID:     run.ID,
@@ -73,7 +74,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		Step:      1,
 	}
 	resp := fiber.Map{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -89,7 +90,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 
 	// makes user that records has been created correctly in database.
 	metric, err := s.MetricFixtures.GetLatestMetricByRunID(context.Background(), run.ID)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), &models.LatestMetric{
 		Key:       "key1",
 		Value:     1.1,
@@ -119,11 +120,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 				return ""
 			},
 			cleanDatabase: func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 		{
@@ -138,11 +139,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 				return ""
 			},
 			cleanDatabase: func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 		{
@@ -159,11 +160,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 				return ""
 			},
 			cleanDatabase: func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 		{
@@ -180,7 +181,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 
 				experiment := &models.Experiment{
 					Name:           uuid.New().String(),
@@ -188,7 +189,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 					LifecycleStage: models.LifecycleStageActive,
 				}
 				_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 
 				run := &models.Run{
 					ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -198,11 +199,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Status:         models.StatusRunning,
 				}
 				run, err = s.RunFixtures.CreateRun(context.Background(), run)
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 				return run.ID
 			},
 			cleanDatabase: func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 	}
@@ -216,7 +217,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 			}
 
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/run/log_parameter_test.go
+++ b/tests/integration/golang/mlflow/run/log_parameter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -36,7 +37,7 @@ func (s *LogParamTestSuite) SetupTest() {
 
 func (s *LogParamTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -44,7 +45,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment := &models.Experiment{
 		Name:           uuid.New().String(),
@@ -52,7 +53,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 	}
 	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run := &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -62,7 +63,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Status:         models.StatusRunning,
 	}
 	run, err = s.RunFixtures.CreateRun(context.Background(), run)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.LogParamRequest{
 		RunID: run.ID,
@@ -70,7 +71,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Value: "value1",
 	}
 	resp := map[string]any{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -91,7 +92,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// missing run_id
 	req := request.LogParamRequest{
@@ -99,7 +100,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Value: "value1",
 	}
 	resp := api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,

--- a/tests/integration/golang/mlflow/run/restore_test.go
+++ b/tests/integration/golang/mlflow/run/restore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -38,7 +39,7 @@ func (s *RestoreRunTestSuite) SetupTest() {
 
 func (s *RestoreRunTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -47,14 +48,14 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -74,7 +75,7 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create tags, metrics, params.
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -82,7 +83,7 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "metric1",
@@ -92,13 +93,13 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 		Step:      1,
 		IsNan:     false,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.RestoreRunRequest{
 		RunID: run.ID,
 	}
 	resp := fiber.Map{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -114,7 +115,7 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 
 	// check that run has been updated in database.
 	run, err = s.RunFixtures.GetRun(context.Background(), run.ID)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), models.LifecycleStageActive, run.LifecycleStage)
 }
 
@@ -124,7 +125,7 @@ func (s *RestoreRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -149,7 +150,7 @@ func (s *RestoreRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/run/search_test.go
+++ b/tests/integration/golang/mlflow/run/search_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -38,7 +39,7 @@ func (s *SearchTestSuite) SetupTest() {
 
 func (s *SearchTestSuite) Test_DefaultNamespace_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create default namespace and experiment.
@@ -47,21 +48,21 @@ func (s *SearchTestSuite) Test_DefaultNamespace_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.testCases(namespace, experiment, false, *experiment.ID)
 }
 
 func (s *SearchTestSuite) Test_DefaultNamespaceExerimentZero_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create default namespace and experiment.
@@ -70,26 +71,26 @@ func (s *SearchTestSuite) Test_DefaultNamespaceExerimentZero_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// update default experiment id.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.testCases(namespace, experiment, false, int32(0))
 }
 
 func (s *SearchTestSuite) Test_CustomNamespace_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create custom namespace and experiment.
@@ -97,21 +98,21 @@ func (s *SearchTestSuite) Test_CustomNamespace_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.testCases(namespace, experiment, true, *experiment.ID)
 }
 
 func (s *SearchTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create custom namespace and experiment.
@@ -119,19 +120,19 @@ func (s *SearchTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// update default experiment id.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	s.testCases(namespace, experiment, true, int32(0))
 }
@@ -161,13 +162,13 @@ func (s *SearchTestSuite) testCases(
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag1",
 		RunID: run1.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "run1",
 		Value:     1.1,
@@ -177,13 +178,13 @@ func (s *SearchTestSuite) testCases(
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run1.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
@@ -203,13 +204,13 @@ func (s *SearchTestSuite) testCases(
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag2",
 		RunID: run2.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "run2",
 		Value:     2.1,
@@ -219,13 +220,13 @@ func (s *SearchTestSuite) testCases(
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param2",
 		Value: "value2",
 		RunID: run2.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
@@ -245,13 +246,13 @@ func (s *SearchTestSuite) testCases(
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag3",
 		RunID: run3.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "run3",
 		Value:     3.1,
@@ -261,13 +262,13 @@ func (s *SearchTestSuite) testCases(
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param3",
 		Value: "value3",
 		RunID: run3.ID,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name     string
@@ -2962,7 +2963,7 @@ func (s *SearchTestSuite) testCases(
 					namespace.Code,
 				)
 			}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				client.DoRequest(
 					fmt.Sprintf("%s%s", mlflow.RunsRoutePrefix, mlflow.RunsSearchRoute),

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -38,7 +39,7 @@ func (s *SetRunTagTestSuite) SetupTest() {
 
 func (s *SetRunTagTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -47,14 +48,14 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -74,7 +75,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.SetRunTagRequest{
 		RunID: run.ID,
@@ -82,7 +83,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		Value: "value1",
 	}
 	resp := fiber.Map{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -98,7 +99,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 
 	// make sure that new tag has been created.
 	tags, err := s.TagFixtures.GetByRunID(context.Background(), run.ID)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), 1, len(tags))
 	assert.Equal(s.T(), []models.Tag{
 		{
@@ -115,7 +116,7 @@ func (s *SetRunTagTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -148,7 +149,7 @@ func (s *SetRunTagTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,

--- a/tests/integration/golang/mlflow/run/update_test.go
+++ b/tests/integration/golang/mlflow/run/update_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -38,7 +39,7 @@ func (s *UpdateRunTestSuite) SetupTest() {
 
 func (s *UpdateRunTestSuite) Test_Ok() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -47,14 +48,14 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -74,7 +75,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	req := request.UpdateRunRequest{
 		RunID:   run.ID,
@@ -83,7 +84,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		EndTime: 1111111111,
 	}
 	resp := response.UpdateRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -107,7 +108,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 
 	// check that run has been updated in database.
 	run, err = s.RunFixtures.GetRun(context.Background(), run.ID)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 	assert.Equal(s.T(), "UpdatedName", run.Name)
 	assert.Equal(s.T(), models.StatusScheduled, run.Status)
 	assert.Equal(s.T(), int64(1111111111), run.EndTime.Int64)
@@ -119,7 +120,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name    string
@@ -142,7 +143,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodPost,


### PR DESCRIPTION
We use `assert.Nil` in our tests to check for errors. This means that if there _was_ an error, the tests will continue and then probably panic further. This PR changes all the places where we used `assert.Nil` to validate that a call was successful to use `require.Nil` instead, which will immediately fail the test and return a clean failure instead of a panic.

There are also places where `assert.Nil` is used to validate that something other than an error is `nil`. Those have not been changed.