### PR TITLE
Improve struct embedding for `helpers.BaseTestSuite`

### DIFF
--- a/tests/integration/golang/admin/namespace/create_test.go
+++ b/tests/integration/golang/admin/namespace/create_test.go
@@ -19,16 +19,11 @@ import (
 )
 
 type CreateNamespaceTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestCreateNamespaceTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateNamespaceTestSuite))
-}
-
-func (s *CreateNamespaceTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *CreateNamespaceTestSuite) Test_Ok() {

--- a/tests/integration/golang/admin/namespace/delete_test.go
+++ b/tests/integration/golang/admin/namespace/delete_test.go
@@ -17,16 +17,11 @@ import (
 )
 
 type DeleteNamespaceTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteNamespaceTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteNamespaceTestSuite))
-}
-
-func (s *DeleteNamespaceTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteNamespaceTestSuite) Test_Ok() {

--- a/tests/integration/golang/admin/namespace/update_test.go
+++ b/tests/integration/golang/admin/namespace/update_test.go
@@ -18,16 +18,11 @@ import (
 )
 
 type UpdateNamespaceTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestUpdateNamespaceTestSuite(t *testing.T) {
 	suite.Run(t, new(UpdateNamespaceTestSuite))
-}
-
-func (s *UpdateNamespaceTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *UpdateNamespaceTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -19,16 +19,11 @@ import (
 )
 
 type CreateAppTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestCreateAppTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateAppTestSuite))
-}
-
-func (s *CreateAppTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *CreateAppTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/app/delete_app_test.go
+++ b/tests/integration/golang/aim/app/delete_app_test.go
@@ -21,16 +21,11 @@ import (
 )
 
 type DeleteAppTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteAppTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteAppTestSuite))
-}
-
-func (s *DeleteAppTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteAppTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/app/get_app_test.go
+++ b/tests/integration/golang/aim/app/get_app_test.go
@@ -20,16 +20,11 @@ import (
 )
 
 type GetAppTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetAppTestSuite(t *testing.T) {
 	suite.Run(t, new(GetAppTestSuite))
-}
-
-func (s *GetAppTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetAppTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -18,16 +18,11 @@ import (
 )
 
 type GetAppsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetAppsTestSuite(t *testing.T) {
 	suite.Run(t, new(GetAppsTestSuite))
-}
-
-func (s *GetAppsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetAppsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/app/update_app_test.go
+++ b/tests/integration/golang/aim/app/update_app_test.go
@@ -22,16 +22,11 @@ import (
 )
 
 type UpdateAppTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestUpdateAppTestSuite(t *testing.T) {
 	suite.Run(t, new(UpdateAppTestSuite))
-}
-
-func (s *UpdateAppTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *UpdateAppTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -22,16 +22,11 @@ import (
 )
 
 type CreateDashboardTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestCreateDashboardTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateDashboardTestSuite))
-}
-
-func (s *CreateDashboardTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *CreateDashboardTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
@@ -21,16 +21,11 @@ import (
 )
 
 type DeleteDashboardTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteDashboardTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteDashboardTestSuite))
-}
-
-func (s *DeleteDashboardTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteDashboardTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -20,16 +20,11 @@ import (
 )
 
 type GetDashboardTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetDashboardTestSuite(t *testing.T) {
 	suite.Run(t, new(GetDashboardTestSuite))
-}
-
-func (s *GetDashboardTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetDashboardTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -20,16 +20,11 @@ import (
 )
 
 type GetDashboardsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetDashboardsTestSuite(t *testing.T) {
 	suite.Run(t, new(GetDashboardsTestSuite))
-}
-
-func (s *GetDashboardsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetDashboardsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -22,16 +22,11 @@ import (
 )
 
 type UpdateDashboardTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestUpdateDashboardTestSuite(t *testing.T) {
 	suite.Run(t, new(UpdateDashboardTestSuite))
-}
-
-func (s *UpdateDashboardTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *UpdateDashboardTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -21,16 +21,11 @@ import (
 )
 
 type DeleteExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteExperimentTestSuite))
-}
-
-func (s *DeleteExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
@@ -19,16 +19,11 @@ import (
 )
 
 type GetExperimentActivityTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetExperimentActivityTestSuite(t *testing.T) {
 	suite.Run(t, new(GetExperimentActivityTestSuite))
-}
-
-func (s *GetExperimentActivityTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetExperimentActivityTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
@@ -19,16 +19,11 @@ import (
 )
 
 type GetExperimentRunsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetExperimentRunsTestSuite(t *testing.T) {
 	suite.Run(t, new(GetExperimentRunsTestSuite))
-}
-
-func (s *GetExperimentRunsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetExperimentRunsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/experiment/get_experiment_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_test.go
@@ -20,16 +20,11 @@ import (
 )
 
 type GetExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(GetExperimentTestSuite))
-}
-
-func (s *GetExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/experiment/get_experiments_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiments_test.go
@@ -20,16 +20,11 @@ import (
 )
 
 type GetExperimentsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetExperimentsTestSuite(t *testing.T) {
 	suite.Run(t, new(GetExperimentTestSuite))
-}
-
-func (s *GetExperimentsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetExperimentsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/metric/search_aligned_test.go
+++ b/tests/integration/golang/aim/metric/search_aligned_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type SearchAlignedMetricsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSearchAlignedMetricsTestSuite(t *testing.T) {
 	suite.Run(t, new(SearchAlignedMetricsTestSuite))
-}
-
-func (s *SearchAlignedMetricsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SearchAlignedMetricsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/metric/search_test.go
+++ b/tests/integration/golang/aim/metric/search_test.go
@@ -22,16 +22,11 @@ import (
 )
 
 type SearchMetricsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSearchMetricsTestSuite(t *testing.T) {
 	suite.Run(t, new(SearchMetricsTestSuite))
-}
-
-func (s *SearchMetricsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SearchMetricsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/project/get_project_activity_test.go
+++ b/tests/integration/golang/aim/project/get_project_activity_test.go
@@ -18,16 +18,11 @@ import (
 )
 
 type GetProjectActivityTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetProjectActivityTestSuite(t *testing.T) {
 	suite.Run(t, new(GetProjectActivityTestSuite))
-}
-
-func (s *GetProjectActivityTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetProjectActivityTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/project/get_project_params_test.go
+++ b/tests/integration/golang/aim/project/get_project_params_test.go
@@ -18,16 +18,11 @@ import (
 )
 
 type GetProjectParamsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetProjectParamsTestSuite(t *testing.T) {
 	suite.Run(t, new(GetProjectParamsTestSuite))
-}
-
-func (s *GetProjectParamsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetProjectParamsTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/project/get_project_status_test.go
+++ b/tests/integration/golang/aim/project/get_project_status_test.go
@@ -16,16 +16,11 @@ import (
 )
 
 type GetProjectStatusTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetProjectStatusTestSuite(t *testing.T) {
 	suite.Run(t, new(GetProjectStatusTestSuite))
-}
-
-func (s *GetProjectStatusTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetProjectStatusTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/project/get_project_test.go
+++ b/tests/integration/golang/aim/project/get_project_test.go
@@ -17,16 +17,11 @@ import (
 )
 
 type GetProjectTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetProjectTestSuite(t *testing.T) {
 	suite.Run(t, new(GetProjectTestSuite))
-}
-
-func (s *GetProjectTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetProjectTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/run/archive_batch_test.go
+++ b/tests/integration/golang/aim/run/archive_batch_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 type ArchiveBatchTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	runs []*models.Run
 }
@@ -29,7 +28,7 @@ func TestArchiveBatchTestSuite(t *testing.T) {
 }
 
 func (s *ArchiveBatchTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,

--- a/tests/integration/golang/aim/run/delete_batch_test.go
+++ b/tests/integration/golang/aim/run/delete_batch_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 type DeleteBatchTestSuite struct {
-	suite.Suite
 	runs []*models.Run
 	helpers.BaseTestSuite
 }
@@ -30,7 +29,7 @@ func TestDeleteBatchTestSuite(t *testing.T) {
 }
 
 func (s *DeleteBatchTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,

--- a/tests/integration/golang/aim/run/delete_test.go
+++ b/tests/integration/golang/aim/run/delete_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 type DeleteRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	runs []*models.Run
 }
@@ -31,7 +30,7 @@ func TestDeleteRunTestSuite(t *testing.T) {
 }
 
 func (s *DeleteRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 type GetRunInfoTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	run *models.Run
 }
@@ -29,7 +28,7 @@ func TestGetRunInfoTestSuite(t *testing.T) {
 }
 
 func (s *GetRunInfoTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,

--- a/tests/integration/golang/aim/run/get_run_metrics_test.go
+++ b/tests/integration/golang/aim/run/get_run_metrics_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 type GetRunMetricsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	run *models.Run
 }
@@ -30,7 +29,7 @@ func TestGetRunMetricsTestSuite(t *testing.T) {
 }
 
 func (s *GetRunMetricsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -20,17 +20,12 @@ import (
 )
 
 type GetRunsActiveTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	runs []*models.Run
 }
 
 func TestGetRunsActiveTestSuite(t *testing.T) {
 	suite.Run(t, new(GetRunsActiveTestSuite))
-}
-
-func (s *GetRunsActiveTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetRunsActiveTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type SearchTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSearchTestSuite(t *testing.T) {
 	suite.Run(t, new(SearchTestSuite))
-}
-
-func (s *SearchTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SearchTestSuite) Test_Ok() {

--- a/tests/integration/golang/aim/run/update_run_test.go
+++ b/tests/integration/golang/aim/run/update_run_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 type UpdateRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	run *models.Run
 }
@@ -31,7 +30,7 @@ func TestUpdateRunTestSuite(t *testing.T) {
 }
 
 func (s *UpdateRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -1,10 +1,10 @@
 package helpers
 
 import (
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"gorm.io/gorm"
 
@@ -15,6 +15,7 @@ import (
 var db *gorm.DB
 
 type BaseTestSuite struct {
+	suite.Suite
 	AIMClient          *HttpClient
 	MlflowClient       *HttpClient
 	AdminClient        *HttpClient
@@ -29,14 +30,14 @@ type BaseTestSuite struct {
 	TagFixtures        *fixtures.TagFixtures
 }
 
-func (s *BaseTestSuite) SetupTest(t *testing.T) {
+func (s *BaseTestSuite) SetupTest() {
 	if db == nil {
 		instance, err := database.NewDBProvider(
 			GetDatabaseUri(),
 			1*time.Second,
 			20,
 		)
-		require.Nil(t, err)
+		require.Nil(s.T(), err)
 		db = instance.GormDB()
 	}
 
@@ -45,41 +46,41 @@ func (s *BaseTestSuite) SetupTest(t *testing.T) {
 	s.AdminClient = NewAdminApiClient(GetServiceUri())
 
 	appFixtures, err := fixtures.NewAppFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.AppFixtures = appFixtures
 
 	dashboardFixtures, err := fixtures.NewDashboardFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.DashboardFixtures = dashboardFixtures
 
 	experimentFixtures, err := fixtures.NewExperimentFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.ExperimentFixtures = experimentFixtures
 
 	metricFixtures, err := fixtures.NewMetricFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.MetricFixtures = metricFixtures
 
 	namespaceFixtures, err := fixtures.NewNamespaceFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.NamespaceFixtures = namespaceFixtures
 
 	projectFixtures, err := fixtures.NewProjectFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.ProjectFixtures = projectFixtures
 
 	paramFixtures, err := fixtures.NewParamFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.ParamFixtures = paramFixtures
 
 	runFixtures, err := fixtures.NewRunFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.RunFixtures = runFixtures
 
 	tagFixtures, err := fixtures.NewTagFixtures(db)
-	require.Nil(t, err)
+	require.Nil(s.T(), err)
 	s.TagFixtures = tagFixtures
 
 	// by default, unload everything.
-	require.Nil(t, s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 }

--- a/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 type GetArtifactGSTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	gsClient    *storage.Client
 	testBuckets []string
@@ -37,14 +36,13 @@ func TestGetArtifactGSTestSuite(t *testing.T) {
 }
 
 func (s *GetArtifactGSTestSuite) SetupSuite() {
-	s.BaseTestSuite.SetupTest(s.T())
-
 	gsClient, err := helpers.NewGSClient(helpers.GetGSEndpointUri())
 	require.Nil(s.T(), err)
 	s.gsClient = gsClient
 }
 
 func (s *GetArtifactGSTestSuite) SetupTest() {
+	s.BaseTestSuite.SetupTest()
 	require.Nil(s.T(), helpers.CreateGSBuckets(s.gsClient, s.testBuckets))
 }
 

--- a/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
@@ -26,16 +26,11 @@ import (
 )
 
 type GetArtifactLocalTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetArtifactLocalTestSuite(t *testing.T) {
 	suite.Run(t, new(GetArtifactLocalTestSuite))
-}
-
-func (s *GetArtifactLocalTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetArtifactLocalTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 type GetArtifactS3TestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	s3Client    *s3.Client
 	testBuckets []string
@@ -38,7 +37,7 @@ func TestGetArtifactS3TestSuite(t *testing.T) {
 }
 
 func (s *GetArtifactS3TestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
 	require.Nil(s.T(), err)

--- a/tests/integration/golang/mlflow/artifact/list_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_gs_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 type ListArtifactGSTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	gsClient    *storage.Client
 	testBuckets []string
@@ -39,14 +38,13 @@ func TestListArtifactGSTestSuite(t *testing.T) {
 }
 
 func (s *ListArtifactGSTestSuite) SetupSuite() {
-	s.BaseTestSuite.SetupTest(s.T())
-
 	gsClient, err := helpers.NewGSClient(helpers.GetGSEndpointUri())
 	require.Nil(s.T(), err)
 	s.gsClient = gsClient
 }
 
 func (s *ListArtifactGSTestSuite) SetupTest() {
+	s.BaseTestSuite.SetupTest()
 	require.Nil(s.T(), helpers.CreateGSBuckets(s.gsClient, s.testBuckets))
 }
 

--- a/tests/integration/golang/mlflow/artifact/list_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_local_test.go
@@ -28,16 +28,11 @@ import (
 )
 
 type ListArtifactLocalTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestListArtifactLocalTestSuite(t *testing.T) {
 	suite.Run(t, new(ListArtifactLocalTestSuite))
-}
-
-func (s *ListArtifactLocalTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *ListArtifactLocalTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 type ListArtifactS3TestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 	s3Client    *s3.Client
 	testBuckets []string
@@ -40,7 +39,7 @@ func TestListArtifactS3TestSuite(t *testing.T) {
 }
 
 func (s *ListArtifactS3TestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
+	s.BaseTestSuite.SetupTest()
 
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
 	require.Nil(s.T(), err)

--- a/tests/integration/golang/mlflow/experiment/create_test.go
+++ b/tests/integration/golang/mlflow/experiment/create_test.go
@@ -22,16 +22,11 @@ import (
 )
 
 type CreateExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestCreateExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateExperimentTestSuite))
-}
-
-func (s *CreateExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *CreateExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/delete_test.go
+++ b/tests/integration/golang/mlflow/experiment/delete_test.go
@@ -24,16 +24,11 @@ import (
 )
 
 type DeleteExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteExperimentTestSuite))
-}
-
-func (s *DeleteExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/get_by_name_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_by_name_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type GetExperimentByNameTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetExperimentByNameTestSuite(t *testing.T) {
 	suite.Run(t, new(GetExperimentByNameTestSuite))
-}
-
-func (s *GetExperimentByNameTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetExperimentByNameTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/get_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type GetExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(GetExperimentTestSuite))
-}
-
-func (s *GetExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/restore_test.go
+++ b/tests/integration/golang/mlflow/experiment/restore_test.go
@@ -24,16 +24,11 @@ import (
 )
 
 type RestoreExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestRestoreExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(RestoreExperimentTestSuite))
-}
-
-func (s *RestoreExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *RestoreExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/search_test.go
+++ b/tests/integration/golang/mlflow/experiment/search_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type SearchExperimentsTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSearchExperimentsTestSuite(t *testing.T) {
 	suite.Run(t, new(SearchExperimentsTestSuite))
-}
-
-func (s *SearchExperimentsTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SearchExperimentsTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
+++ b/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type SetExperimentTagTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSetExperimentTagTestSuite(t *testing.T) {
 	suite.Run(t, new(SetExperimentTagTestSuite))
-}
-
-func (s *SetExperimentTagTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SetExperimentTagTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/experiment/update_test.go
+++ b/tests/integration/golang/mlflow/experiment/update_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type UpdateExperimentTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestUpdateExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(UpdateExperimentTestSuite))
-}
-
-func (s *UpdateExperimentTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *UpdateExperimentTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type GetHistoriesTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetHistoriesTestSuite(t *testing.T) {
 	suite.Run(t, new(GetHistoriesTestSuite))
-}
-
-func (s *GetHistoriesTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetHistoriesTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -22,16 +22,11 @@ import (
 )
 
 type GetHistoriesBulkTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetHistoriesBulkTestSuite(t *testing.T) {
 	suite.Run(t, new(GetHistoriesBulkTestSuite))
-}
-
-func (s *GetHistoriesBulkTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetHistoriesBulkTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -21,16 +21,11 @@ import (
 )
 
 type GetHistoryTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetHistoryTestSuite(t *testing.T) {
 	suite.Run(t, new(GetHistoryTestSuite))
-}
-
-func (s *GetHistoryTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetHistoryTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type CreateRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestCreateRunTestSuite(t *testing.T) {
 	suite.Run(t, new(CreateRunTestSuite))
-}
-
-func (s *CreateRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *CreateRunTestSuite) Test_DefaultNamespace_Ok() {

--- a/tests/integration/golang/mlflow/run/delete_tag_test.go
+++ b/tests/integration/golang/mlflow/run/delete_tag_test.go
@@ -25,16 +25,11 @@ import (
 )
 
 type DeleteRunTagTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteRunTagTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteRunTagTestSuite))
-}
-
-func (s *DeleteRunTagTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteRunTagTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/delete_test.go
+++ b/tests/integration/golang/mlflow/run/delete_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type DeleteRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestDeleteRunTestSuite(t *testing.T) {
 	suite.Run(t, new(DeleteRunTestSuite))
-}
-
-func (s *DeleteRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *DeleteRunTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -24,16 +24,11 @@ import (
 )
 
 type GetRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestGetRunTestSuite(t *testing.T) {
 	suite.Run(t, new(GetRunTestSuite))
-}
-
-func (s *GetRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *GetRunTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type LogBatchTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestLogBatchTestSuite(t *testing.T) {
 	suite.Run(t, new(LogBatchTestSuite))
-}
-
-func (s *LogBatchTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *LogBatchTestSuite) TestTags_Ok() {

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -24,16 +24,11 @@ import (
 )
 
 type LogMetricTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestLogMetricTestSuite(t *testing.T) {
 	suite.Run(t, new(LogMetricTestSuite))
-}
-
-func (s *LogMetricTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *LogMetricTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/log_parameter_test.go
+++ b/tests/integration/golang/mlflow/run/log_parameter_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 type LogParamTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestLogParamTestSuite(t *testing.T) {
 	suite.Run(t, new(LogParamTestSuite))
-}
-
-func (s *LogParamTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *LogParamTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/restore_test.go
+++ b/tests/integration/golang/mlflow/run/restore_test.go
@@ -25,16 +25,11 @@ import (
 )
 
 type RestoreRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestRestoreRunTestSuite(t *testing.T) {
 	suite.Run(t, new(RestoreRunTestSuite))
-}
-
-func (s *RestoreRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *RestoreRunTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/search_test.go
+++ b/tests/integration/golang/mlflow/run/search_test.go
@@ -25,16 +25,11 @@ import (
 )
 
 type SearchTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSearchTestSuite(t *testing.T) {
 	suite.Run(t, new(SearchTestSuite))
-}
-
-func (s *SearchTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SearchTestSuite) Test_DefaultNamespace_Ok() {

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -25,16 +25,11 @@ import (
 )
 
 type SetRunTagTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestSetRunTagTestSuite(t *testing.T) {
 	suite.Run(t, new(SetRunTagTestSuite))
-}
-
-func (s *SetRunTagTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *SetRunTagTestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/run/update_test.go
+++ b/tests/integration/golang/mlflow/run/update_test.go
@@ -25,16 +25,11 @@ import (
 )
 
 type UpdateRunTestSuite struct {
-	suite.Suite
 	helpers.BaseTestSuite
 }
 
 func TestUpdateRunTestSuite(t *testing.T) {
 	suite.Run(t, new(UpdateRunTestSuite))
-}
-
-func (s *UpdateRunTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest(s.T())
 }
 
 func (s *UpdateRunTestSuite) Test_Ok() {


### PR DESCRIPTION
This PR removes a lot of boilerplate code that was used to call `BaseTestSuite.SetupTest`.