### PR TITLE
[release/0.3] Permit duplicate param logging

### DIFF
--- a/pkg/api/mlflow/dao/repositories/helpers.go
+++ b/pkg/api/mlflow/dao/repositories/helpers.go
@@ -1,0 +1,32 @@
+package repositories
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
+)
+
+// makeSqlPlaceholders collects a string of "(?,?,?), (?,?,?)" and so on,
+// for use as sql parameters
+func makeSqlPlaceholders(numberInEachSet, numberOfSets int) string {
+	set := fmt.Sprintf("(%s)", strings.Repeat("?,", numberInEachSet-1)+"?")
+	return strings.Repeat(set+",", numberOfSets-1) + set
+}
+
+// makeParamConflictPlaceholdersAndValues provides sql placeholders and concatenates
+// Key, Value, RunID from each input Param for use in sql values replacement
+func makeParamConflictPlaceholdersAndValues(params []models.Param) (string, []interface{}) {
+	// make place holders of 3 fields for each param
+	placeholders := makeSqlPlaceholders(3, len(params))
+	// values array is params * 3 in length since using 3 fields from each
+	valuesArray := make([]interface{}, len(params)*3)
+	index := 0
+	for _, param := range params {
+		valuesArray[index] = param.Key
+		valuesArray[index+1] = param.Value
+		valuesArray[index+2] = param.RunID
+		index = index + 3
+	}
+	return placeholders, valuesArray
+}

--- a/pkg/api/mlflow/dao/repositories/helpers_test.go
+++ b/pkg/api/mlflow/dao/repositories/helpers_test.go
@@ -1,0 +1,55 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
+)
+
+func Test_makeSqlPlaceholders(t *testing.T) {
+	tests := []struct {
+		numberInEachSet int
+		numberOfSets    int
+		expectedResult  string
+	}{
+		{numberInEachSet: 1, numberOfSets: 1, expectedResult: "(?)"},
+		{numberInEachSet: 2, numberOfSets: 1, expectedResult: "(?,?)"},
+		{numberInEachSet: 1, numberOfSets: 2, expectedResult: "(?),(?)"},
+		{numberInEachSet: 2, numberOfSets: 2, expectedResult: "(?,?),(?,?)"},
+	}
+
+	for _, tt := range tests {
+		result := makeSqlPlaceholders(tt.numberInEachSet, tt.numberOfSets)
+		assert.Equal(t, tt.expectedResult, result)
+	}
+}
+
+func Test_makeParamConflictPlaceholdersAndValues(t *testing.T) {
+	tests := []struct {
+		params               []models.Param
+		expectedPlaceholders string
+		expectedValues       []interface{}
+	}{
+		{
+			params:               []models.Param{{Key: "key1", Value: "value1", RunID: "run1"}},
+			expectedPlaceholders: "(?,?,?)",
+			expectedValues:       []interface{}{"key1", "value1", "run1"},
+		},
+		{
+			params: []models.Param{
+				{Key: "key1", Value: "value1", RunID: "run1"},
+				{Key: "key2", Value: "value2", RunID: "run2"},
+			},
+			expectedPlaceholders: "(?,?,?),(?,?,?)",
+			expectedValues:       []interface{}{"key1", "value1", "run1", "key2", "value2", "run2"},
+		},
+	}
+
+	for _, tt := range tests {
+		placeholders, values := makeParamConflictPlaceholdersAndValues(tt.params)
+		assert.Equal(t, tt.expectedPlaceholders, placeholders)
+		assert.Equal(t, tt.expectedValues, values)
+	}
+}

--- a/pkg/api/mlflow/dao/repositories/param.go
+++ b/pkg/api/mlflow/dao/repositories/param.go
@@ -6,9 +6,33 @@ import (
 
 	"github.com/rotisserie/eris"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 )
+
+// ParamConflictError is returned when there is a conflict in the params (same key, different value).
+type ParamConflictError struct {
+	Message string
+}
+
+// Error returns the ParamConflictError message.
+func (e ParamConflictError) Error() string {
+	return e.Message
+}
+
+// paramConflict represents a conflicting parameter.
+type paramConflict struct {
+	RunID    string `gorm:"column:run_uuid"`
+	Key      string
+	OldValue string
+	NewValue string
+}
+
+// String renders the paramConflict for error messages.
+func (pc paramConflict) String() string {
+	return fmt.Sprintf("{run_id: %s, key: %s, old_value: %s, new_value: %s}", pc.RunID, pc.Key, pc.OldValue, pc.NewValue)
+}
 
 // ParamRepositoryProvider provides an interface to work with models.Param entity.
 type ParamRepositoryProvider interface {
@@ -32,48 +56,46 @@ func NewParamRepository(db *gorm.DB) *ParamRepository {
 
 // CreateBatch creates []models.Param entities in batch.
 func (r ParamRepository) CreateBatch(ctx context.Context, batchSize int, params []models.Param) error {
-	// try to create params in batch; error condition requires special handling
-	// to allow certain duplicates
-	if err := r.db.CreateInBatches(params, batchSize).Error; err != nil {
-		// remove duplicate rows and try again
-		dedupedParams, errRemovingMatches := r.removeExactMatches(ctx, params)
-		if errRemovingMatches != nil {
-			return eris.Wrap(errRemovingMatches, "error removing duplicates in batch")
+	if err := r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.WithContext(ctx).Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "run_uuid"}, {Name: "key"}},
+			DoNothing: true,
+		}).CreateInBatches(params, batchSize).Error; err != nil {
+			return eris.Wrap(err, "error creating params in batch")
 		}
-		if err := r.db.CreateInBatches(dedupedParams, batchSize).Error; err != nil {
-			return eris.Wrap(err, "error creating params in batch after removing duplicates")
+		// if there were ignored conflicts, verify to be exact duplicates
+		if tx.RowsAffected != int64(len(params)) {
+			conflictingParams, err := findConflictingParams(tx, params)
+			if err != nil {
+				return eris.Wrap(err, "error checking for conflicting params")
+			}
+			if len(conflictingParams) > 0 {
+				return ParamConflictError{
+					Message: fmt.Sprintf("conflicting params found: %v", conflictingParams),
+				}
+			}
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	return nil
 }
 
-// removeExactMatches will return a new slice of params which excludes exact matches
-func (r ParamRepository) removeExactMatches(ctx context.Context, params []models.Param) ([]models.Param, error) {
-	var keys []string
-	paramMap := map[string]models.Param{}
-	for _, param := range params {
-		key := fmt.Sprintf("%v-%v-%v", param.RunID, param.Key, param.Value)
-		keys = append(keys, key)
-		paramMap[key] = param
+// findConflictingParams checks if there are conflicting values for the input params. If a key does not
+// yet exist in the db, or if the same key and value already exist for the run, it is not a conflict.
+// If the key already exists for the run but with a different value, it is a conflict. Conflicts are returned.
+func findConflictingParams(tx *gorm.DB, params []models.Param) ([]paramConflict, error) {
+	var conflicts []paramConflict
+	placeholders, values := makeParamConflictPlaceholdersAndValues(params)
+	sql := fmt.Sprintf(`WITH new(key, value, run_uuid) AS (VALUES %s)
+		     SELECT current.run_uuid, current.key, current.value as old_value, new.value as new_value
+		     FROM params AS current
+		     INNER JOIN new USING (run_uuid, key)
+		     WHERE new.value != current.value`, placeholders)
+	if err := tx.Raw(sql, values...).
+		Find(&conflicts).Error; err != nil {
+		return nil, eris.Wrap(err, "error fetching params from db")
 	}
-
-	var foundKeys []string
-	if err := r.db.Raw(`
-		select run_uuid || '-' || key || '-' || value
-		from params
-		where run_uuid || '-' || key || '-' || value in ?`, keys).
-		Find(&foundKeys).Error; err != nil {
-		return []models.Param{}, eris.Wrap(err, "problem selecting existing params")
-	}
-
-	for _, foundKey := range foundKeys {
-		delete(paramMap, foundKey)
-	}
-
-	paramsToReturn := []models.Param{}
-	for _, v := range paramMap {
-		paramsToReturn = append(paramsToReturn, v)
-	}
-
-	return paramsToReturn, nil
+	return conflicts, nil
 }

--- a/tests/integration/golang/fixtures/param.go
+++ b/tests/integration/golang/fixtures/param.go
@@ -31,3 +31,12 @@ func (f ParamFixtures) CreateParam(ctx context.Context, param *models.Param) (*m
 	}
 	return param, nil
 }
+
+// GetParamsByRunID returns all params for a given run.
+func (f ParamFixtures) GetParamsByRunID(ctx context.Context, runID string) ([]models.Param, error) {
+	var params []models.Param
+	if err := f.baseFixtures.db.WithContext(ctx).Where("run_uuid = ?", runID).Find(&params).Error; err != nil {
+		return nil, eris.Wrap(err, "error getting params by run id")
+	}
+	return params, nil
+}

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -25,6 +25,7 @@ type LogBatchTestSuite struct {
 	client             *helpers.HttpClient
 	runFixtures        *fixtures.RunFixtures
 	metricFixtures     *fixtures.MetricFixtures
+	paramFixtures      *fixtures.ParamFixtures
 	experimentFixtures *fixtures.ExperimentFixtures
 }
 
@@ -40,6 +41,9 @@ func (s *LogBatchTestSuite) SetupTest() {
 	metricFixtures, err := fixtures.NewMetricFixtures(helpers.GetDatabaseUri())
 	assert.Nil(s.T(), err)
 	s.metricFixtures = metricFixtures
+	paramFixtures, err := fixtures.NewParamFixtures(helpers.GetDatabaseUri())
+	assert.Nil(s.T(), err)
+	s.paramFixtures = paramFixtures
 	expFixtures, err := fixtures.NewExperimentFixtures(helpers.GetDatabaseUri())
 	assert.Nil(s.T(), err)
 	s.experimentFixtures = expFixtures
@@ -116,6 +120,14 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 	})
 	assert.Nil(s.T(), err)
 
+	// create preexisting param (other batch) for conflict testing
+	_, err = s.paramFixtures.CreateParam(context.Background(), &models.Param{
+		RunID: run.ID,
+		Key:   "key1",
+		Value: "value1",
+	})
+	assert.Nil(s.T(), err)
+
 	tests := []struct {
 		name    string
 		request *request.LogBatchRequest
@@ -133,7 +145,19 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 			},
 		},
 		{
-			name: "LogDuplicate",
+			name: "LogDuplicateSeparateBatch",
+			request: &request.LogBatchRequest{
+				RunID: run.ID,
+				Params: []request.ParamPartialRequest{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+				},
+			},
+		},
+		{
+			name: "LogDuplicateSameBatch",
 			request: &request.LogBatchRequest{
 				RunID: run.ID,
 				Params: []request.ParamPartialRequest{
@@ -159,6 +183,13 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 			)
 			assert.Nil(s.T(), err)
 			assert.Empty(s.T(), resp)
+
+			// verify params are inserted
+			params, err := s.paramFixtures.GetParamsByRunID(context.Background(), run.ID)
+			assert.Nil(s.T(), err)
+			for _, param := range tt.request.Params {
+				assert.Contains(s.T(), params, models.Param{Key: param.Key, Value: param.Value, RunID: run.ID})
+			}
 		})
 	}
 }
@@ -360,7 +391,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 		},
 		{
 			name:  "DuplicateKeyDifferentValueFails",
-			error: api.NewInternalError("unable to insert params for run"),
+			error: api.NewInvalidParameterValueError("unable to insert params for run"),
 			request: &request.LogBatchRequest{
 				RunID: run.ID,
 				Params: []request.ParamPartialRequest{
@@ -370,6 +401,10 @@ func (s *LogBatchTestSuite) Test_Error() {
 					},
 					{
 						Key:   "key1",
+						Value: "value2",
+					},
+					{
+						Key:   "key2",
 						Value: "value2",
 					},
 				},
@@ -388,6 +423,11 @@ func (s *LogBatchTestSuite) Test_Error() {
 			assert.Nil(t, err)
 			assert.Equal(s.T(), tt.error.ErrorCode, resp.ErrorCode)
 			assert.Contains(s.T(), resp.Error(), tt.error.Message)
+
+			// there should be no params inserted when error occurs.
+			params, err := s.paramFixtures.GetParamsByRunID(context.Background(), run.ID)
+			assert.Nil(s.T(), err)
+			assert.Empty(s.T(), params)
 		})
 	}
 }


### PR DESCRIPTION
* Rely on database to detect duplicate parameter logging where the value has changed and prevent them
* Fail the entire batch when an invalid duplicate parameter is detected
* Return HTTP 400 instead of 500 in case of duplication

Backport of #550.
Fixes #523.