### PR TITLE
Use `require` instead of `assert` for checking errors in tests

### DIFF
--- a/pkg/api/mlflow/service/artifact/service_test.go
+++ b/pkg/api/mlflow/service/artifact/service_test.go
@@ -219,10 +219,10 @@ func TestService_GetArtifact_Ok(t *testing.T) {
 		},
 	)
 
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := new(bytes.Buffer)
 	_, err = result.ReadFrom(data)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "content", result.String())
 }
 

--- a/tests/integration/golang/database/migrate_test.go
+++ b/tests/integration/golang/database/migrate_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/G-Research/fasttrackml/pkg/database"
 )
@@ -24,15 +24,15 @@ func testMigrateWithSchema(t *testing.T, schema string) {
 	// setup sqlite MLFlow database from the schema
 	mlflowDBPath := path.Join(t.TempDir(), "mlflow.db")
 	mlflowDB, err := sql.Open("sqlite3", mlflowDBPath)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	//nolint:gosec
 	mlflowSql, err := os.ReadFile(schema)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	_, err = mlflowDB.Exec(string(mlflowSql))
-	assert.Nil(t, err)
-	assert.Nil(t, mlflowDB.Close())
+	require.Nil(t, err)
+	require.Nil(t, mlflowDB.Close())
 
 	// make DbProvider using our package
 	db, err := database.NewDBProvider(
@@ -40,8 +40,8 @@ func testMigrateWithSchema(t *testing.T, schema string) {
 		1*time.Second,
 		20,
 	)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// run migrations
-	assert.Nil(t, database.CheckAndMigrateDB(true, db.GormDB()))
+	require.Nil(t, database.CheckAndMigrateDB(true, db.GormDB()))
 }

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -40,14 +40,14 @@ func (s *GetArtifactS3TestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
-	assert.Nil(s.T(), err)
-	assert.Nil(s.T(), helpers.CreateS3Buckets(s3Client, s.testBuckets))
+	require.Nil(s.T(), err)
+	require.Nil(s.T(), helpers.CreateS3Buckets(s3Client, s.testBuckets))
 
 	s.s3Client = s3Client
 }
 
 func (s *GetArtifactS3TestSuite) TearDownTest() {
-	assert.Nil(s.T(), helpers.RemoveS3Buckets(s.s3Client, s.testBuckets))
+	require.Nil(s.T(), helpers.RemoveS3Buckets(s.s3Client, s.testBuckets))
 }
 
 func (s *GetArtifactS3TestSuite) Test_Ok() {

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -135,7 +135,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 
 func (s *GetHistoriesTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -129,7 +129,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 
 func (s *GetHistoriesBulkTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -98,7 +98,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 
 func (s *GetHistoryTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/namespace/flows/artifact_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/artifact_test.go
@@ -42,7 +42,7 @@ func TestArtifactFlowTestSuite(t *testing.T) {
 }
 
 func (s *ArtifactFlowTestSuite) TearDownTest() {
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *ArtifactFlowTestSuite) Test_Ok() {
@@ -103,8 +103,8 @@ func (s *ArtifactFlowTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			defer func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
-				assert.Nil(s.T(), helpers.RemoveS3Buckets(s.s3Client, s.testBuckets))
+				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				require.Nil(s.T(), helpers.RemoveS3Buckets(s.s3Client, s.testBuckets))
 			}()
 
 			// setup data under the test.
@@ -131,7 +131,7 @@ func (s *ArtifactFlowTestSuite) Test_Ok() {
 			require.Nil(s.T(), err)
 
 			// create test buckets.
-			assert.Nil(s.T(), helpers.CreateS3Buckets(s.s3Client, s.testBuckets))
+			require.Nil(s.T(), helpers.CreateS3Buckets(s.s3Client, s.testBuckets))
 
 			// run actual flow test over the test data.
 			s.testRunArtifactFlow(tt.namespace1Code, tt.namespace2Code, experiment1, experiment2)
@@ -192,7 +192,7 @@ func (s *ArtifactFlowTestSuite) testRunArtifactFlow(
 	// check that there is no intersection between runs, so when we request
 	// run 1 in scope of namespace 2 and run 2 in scope of namespace 1 API will throw an error.
 	resp := api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -214,7 +214,7 @@ func (s *ArtifactFlowTestSuite) testRunArtifactFlow(
 	assert.Equal(s.T(), api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
 
 	resp = api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -250,7 +250,7 @@ func (s *ArtifactFlowTestSuite) testRunArtifactFlow(
 	// check that there is no intersection between runs, so when we request
 	// run 1 in scope of namespace 2 and run 2 in scope of namespace 1 API will throw an error.
 	resp = api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -272,7 +272,7 @@ func (s *ArtifactFlowTestSuite) testRunArtifactFlow(
 	assert.Equal(s.T(), api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
 
 	resp = api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -296,7 +296,7 @@ func (s *ArtifactFlowTestSuite) testRunArtifactFlow(
 
 func (s *ArtifactFlowTestSuite) createRun(namespace string, req *request.CreateRunRequest) string {
 	resp := response.CreateRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -319,7 +319,7 @@ func (s *ArtifactFlowTestSuite) listRunArtifactsAndCompare(
 	namespace string, req request.ListArtifactsRequest, expectedResponse []response.FilePartialResponse,
 ) {
 	actualResponse := response.ListArtifactsResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -342,7 +342,7 @@ func (s *ArtifactFlowTestSuite) getRunArtifactAndCompare(
 	namespace string, req request.GetArtifactRequest, expectedResponse string,
 ) {
 	actualResponse := new(bytes.Buffer)
-	assert.Nil(s.T(), s.MlflowClient.WithMethod(
+	require.Nil(s.T(), s.MlflowClient.WithMethod(
 		http.MethodGet,
 	).WithNamespace(
 		namespace,

--- a/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -40,7 +41,7 @@ func TestExperimentFlowTestSuite(t *testing.T) {
 }
 
 func (s *ExperimentFlowTestSuite) TearDownTest() {
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *ExperimentFlowTestSuite) Test_Ok() {
@@ -96,17 +97,17 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 
 	// delete everything before the test, because when service starts under the hood we create
 	// default namespace and experiment, so it could lead to the problems with actual tests.
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
-			defer assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 			_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), namespace2)
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// 2. run actual flow test over the test data.
 			s.testExperimentFlow(tt.namespace1Code, tt.namespace2Code)
@@ -159,7 +160,7 @@ func (s *ExperimentFlowTestSuite) testExperimentFlow(namespace1Code, namespace2C
 	// check that there is no intersection between experiments, so when we request
 	// experiment 1 in scope of namespace 2 and experiment 2 in scope of namespace 1 API will throw an error.
 	resp := api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -187,7 +188,7 @@ func (s *ExperimentFlowTestSuite) testExperimentFlow(namespace1Code, namespace2C
 	assert.Equal(s.T(), api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
 
 	resp = api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -428,7 +429,7 @@ func (s *ExperimentFlowTestSuite) createExperiment(
 	namespace string, req *request.CreateExperimentRequest,
 ) string {
 	resp := response.CreateExperimentResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -447,7 +448,7 @@ func (s *ExperimentFlowTestSuite) createExperiment(
 }
 
 func (s *ExperimentFlowTestSuite) updateExperiment(namespace string, req *request.UpdateExperimentRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -465,7 +466,7 @@ func (s *ExperimentFlowTestSuite) searchExperimentAndCompare(
 	namespace string, expectedExperiments []*response.ExperimentPartialResponse,
 ) {
 	searchResp := response.SearchExperimentsResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithQuery(
 			request.SearchExperimentsRequest{},
@@ -486,7 +487,7 @@ func (s *ExperimentFlowTestSuite) getExperimentByIDAndCompare(
 	namespace string, experimentID string, expectedResponse *response.GetExperimentResponse,
 ) *response.GetExperimentResponse {
 	resp := response.GetExperimentResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -514,7 +515,7 @@ func (s *ExperimentFlowTestSuite) getExperimentByNameAndCompare(
 	namespace string, name string, expectedResponse *response.GetExperimentResponse,
 ) {
 	resp := response.GetExperimentResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -538,7 +539,7 @@ func (s *ExperimentFlowTestSuite) getExperimentByNameAndCompare(
 }
 
 func (s *ExperimentFlowTestSuite) deleteExperiment(namespace, experiment1ID string) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -555,7 +556,7 @@ func (s *ExperimentFlowTestSuite) deleteExperiment(namespace, experiment1ID stri
 }
 
 func (s *ExperimentFlowTestSuite) restoreExperiment(namespace, experiment1ID string) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -572,7 +573,7 @@ func (s *ExperimentFlowTestSuite) restoreExperiment(namespace, experiment1ID str
 }
 
 func (s *ExperimentFlowTestSuite) setExperimentTag(namespace string, req *request.SetExperimentTagRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,

--- a/tests/integration/golang/mlflow/namespace/flows/metric_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/metric_test.go
@@ -34,7 +34,7 @@ func TestMetricFlowTestSuite(t *testing.T) {
 }
 
 func (s *MetricFlowTestSuite) TearDownTest() {
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *MetricFlowTestSuite) Test_Ok() {
@@ -90,7 +90,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
-			defer assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
@@ -327,7 +327,7 @@ func (s *MetricFlowTestSuite) createRun(
 	namespace string, req *request.CreateRunRequest,
 ) string {
 	resp := response.CreateRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -348,7 +348,7 @@ func (s *MetricFlowTestSuite) getRunAndCompare(
 	namespace string, req request.GetRunRequest, expectedResponse *response.GetRunResponse,
 ) {
 	resp := response.GetRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -380,7 +380,7 @@ func (s *MetricFlowTestSuite) getRunAndCompare(
 }
 
 func (s *MetricFlowTestSuite) logRunMetric(namespace string, req *request.LogMetricRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -398,7 +398,7 @@ func (s *MetricFlowTestSuite) getMetricHistoryBulkAndCompare(
 	namespace string, req request.GetMetricHistoryBulkRequest, expectedResponse response.GetMetricHistoryResponse,
 ) {
 	actualResponse := response.GetMetricHistoryResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithNamespace(
 			namespace,
@@ -419,7 +419,7 @@ func (s *MetricFlowTestSuite) getMetricHistoryAndCompare(
 	namespace string, req request.GetMetricHistoryRequest, expectedResponse response.GetMetricHistoryResponse,
 ) {
 	actualResponse := response.GetMetricHistoryResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,

--- a/tests/integration/golang/mlflow/namespace/flows/run_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/run_test.go
@@ -43,7 +43,7 @@ func TestRunFlowTestSuite(t *testing.T) {
 }
 
 func (s *RunFlowTestSuite) TearDownTest() {
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *RunFlowTestSuite) Test_Ok() {
@@ -99,7 +99,7 @@ func (s *RunFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
-			defer assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
@@ -190,7 +190,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 	// check that there is no intersection between runs, so when we request
 	// run 1 in scope of namespace 2 and run 2 in scope of namespace 1 API will throw an error.
 	resp := api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -210,7 +210,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 	assert.Equal(s.T(), api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
 
 	resp = api.ErrorResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -854,7 +854,7 @@ func (s *RunFlowTestSuite) createRun(
 	namespace string, req *request.CreateRunRequest,
 ) string {
 	resp := response.CreateRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -875,7 +875,7 @@ func (s *RunFlowTestSuite) getRunAndCompare(
 	namespace string, req request.GetRunRequest, expectedResponse *response.GetRunResponse,
 ) *response.GetRunResponse {
 	resp := response.GetRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodGet,
@@ -909,7 +909,7 @@ func (s *RunFlowTestSuite) getRunAndCompare(
 
 func (s *RunFlowTestSuite) updateRun(namespace string, req *request.UpdateRunRequest) {
 	resp := response.UpdateRunResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -929,7 +929,7 @@ func (s *RunFlowTestSuite) searchRunsAndCompare(
 	namespace string, req request.SearchRunsRequest, expectedRuns []*response.RunPartialResponse,
 ) {
 	searchResp := response.SearchRunsResponse{}
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -949,7 +949,7 @@ func (s *RunFlowTestSuite) searchRunsAndCompare(
 }
 
 func (s *RunFlowTestSuite) deleteRun(namespace string, req *request.DeleteRunRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -964,7 +964,7 @@ func (s *RunFlowTestSuite) deleteRun(namespace string, req *request.DeleteRunReq
 }
 
 func (s *RunFlowTestSuite) restoreRun(namespace string, req *request.RestoreRunRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -979,7 +979,7 @@ func (s *RunFlowTestSuite) restoreRun(namespace string, req *request.RestoreRunR
 }
 
 func (s *RunFlowTestSuite) logRunMetric(namespace string, req *request.LogMetricRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -994,7 +994,7 @@ func (s *RunFlowTestSuite) logRunMetric(namespace string, req *request.LogMetric
 }
 
 func (s *RunFlowTestSuite) logRunParam(namespace string, req *request.LogParamRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -1009,7 +1009,7 @@ func (s *RunFlowTestSuite) logRunParam(namespace string, req *request.LogParamRe
 }
 
 func (s *RunFlowTestSuite) setRunTag(namespace string, req *request.SetRunTagRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -1024,7 +1024,7 @@ func (s *RunFlowTestSuite) setRunTag(namespace string, req *request.SetRunTagReq
 }
 
 func (s *RunFlowTestSuite) deleteRunTag(namespace string, req *request.DeleteRunTagRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,
@@ -1039,7 +1039,7 @@ func (s *RunFlowTestSuite) deleteRunTag(namespace string, req *request.DeleteRun
 }
 
 func (s *RunFlowTestSuite) runLogBatch(namespace string, req *request.LogBatchRequest) {
-	assert.Nil(
+	require.Nil(
 		s.T(),
 		s.MlflowClient.WithMethod(
 			http.MethodPost,

--- a/tests/integration/golang/mlflow/namespace/namespace_test.go
+++ b/tests/integration/golang/mlflow/namespace/namespace_test.go
@@ -30,7 +30,7 @@ func TestNamespaceTestSuite(t *testing.T) {
 }
 
 func (s *NamespaceTestSuite) TearDownTest() {
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *NamespaceTestSuite) Test_Ok() {
@@ -98,10 +98,10 @@ func (s *NamespaceTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
-			defer assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			experiment := tt.setup()
 			resp := response.GetExperimentResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodGet,
@@ -149,7 +149,7 @@ func (s *NamespaceTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(T *testing.T) {
 			resp := api.ErrorResponse{}
-			assert.Nil(
+			require.Nil(
 				s.T(),
 				s.MlflowClient.WithMethod(
 					http.MethodGet,

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -196,7 +196,7 @@ func (s *CreateRunTestSuite) successCases(
 
 func (s *CreateRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -216,7 +216,7 @@ func (s *CreateRunTestSuite) Test_Error() {
 	// set namespace default experiment.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	assert.Nil(s.T(), err)
+	require.Nil(s.T(), err)
 
 	tests := []struct {
 		name      string

--- a/tests/integration/golang/mlflow/run/delete_test.go
+++ b/tests/integration/golang/mlflow/run/delete_test.go
@@ -99,7 +99,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 
 func (s *DeleteRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -145,7 +145,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 
 func (s *GetRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/run/log_parameter_test.go
+++ b/tests/integration/golang/mlflow/run/log_parameter_test.go
@@ -103,7 +103,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 
 func (s *LogParamTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/run/restore_test.go
+++ b/tests/integration/golang/mlflow/run/restore_test.go
@@ -116,7 +116,7 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 
 func (s *RestoreRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -107,7 +107,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 
 func (s *SetRunTagTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/mlflow/run/update_test.go
+++ b/tests/integration/golang/mlflow/run/update_test.go
@@ -111,7 +111,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 
 func (s *UpdateRunTestSuite) Test_Error() {
 	defer func() {
-		assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{


### PR DESCRIPTION
Same logic as #584. Implemented again following some changes made in #582.