### PR TITLE
Correct subtest usage in testsuites

### DIFF
--- a/pkg/api/aim/query/query_test.go
+++ b/pkg/api/aim/query/query_test.go
@@ -124,7 +124,7 @@ func (s *QueryTestSuite) TestPostgresDialector_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			pq := QueryParser{
 				Default: DefaultExpression{
 					Contains:   "run.archived",
@@ -237,7 +237,7 @@ func (s *QueryTestSuite) TestSqliteDialector_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			pq := QueryParser{
 				Default: DefaultExpression{
 					Contains:   "run.archived",

--- a/tests/integration/golang/admin/namespace/create_test.go
+++ b/tests/integration/golang/admin/namespace/create_test.go
@@ -124,7 +124,7 @@ func (s *CreateNamespaceTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			var resp goquery.Document
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/admin/namespace/delete_test.go
+++ b/tests/integration/golang/admin/namespace/delete_test.go
@@ -59,7 +59,7 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			require.Nil(
 				s.T(),
 				s.AdminClient().WithMethod(
@@ -110,7 +110,7 @@ func (s *DeleteNamespaceTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			var resp any
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/admin/namespace/update_test.go
+++ b/tests/integration/golang/admin/namespace/update_test.go
@@ -127,7 +127,7 @@ func (s *UpdateNamespaceTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			var resp any
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -53,7 +53,7 @@ func (s *CreateAppTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.App
 			require.Nil(
 				s.T(),
@@ -101,7 +101,7 @@ func (s *CreateAppTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/app/delete_app_test.go
+++ b/tests/integration/golang/aim/app/delete_app_test.go
@@ -61,7 +61,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			require.Nil(
 				s.T(),
 				s.AIMClient().WithMethod(
@@ -112,7 +112,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/app/get_app_test.go
+++ b/tests/integration/golang/aim/app/get_app_test.go
@@ -81,7 +81,7 @@ func (s *GetAppTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/apps/%v", tt.idParam))
 			assert.Equal(s.T(), "Not Found", resp.Message)

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -40,7 +40,7 @@ func (s *GetAppsTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer func() {
 				require.Nil(s.T(), s.AppFixtures.UnloadFixtures())
 			}()

--- a/tests/integration/golang/aim/app/update_app_test.go
+++ b/tests/integration/golang/aim/app/update_app_test.go
@@ -67,7 +67,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.App
 			require.Nil(
 				s.T(),
@@ -144,7 +144,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -67,7 +67,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Dashboard
 			require.Nil(
 				s.T(),
@@ -119,7 +119,7 @@ func (s *CreateDashboardTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
@@ -74,7 +74,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),
@@ -141,7 +141,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -95,7 +95,7 @@ func (s *GetDashboardTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -42,7 +42,7 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer func() {
 				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			}()

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -78,7 +78,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Dashboard
 			require.Nil(
 				s.T(),
@@ -174,7 +174,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(s.T(), s.AIMClient().WithMethod(
 				http.MethodPut,

--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -113,7 +113,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
@@ -93,7 +93,7 @@ func (s *GetExperimentActivityTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
 			require.Nil(s.T(), s.AIMClient().WithQuery(map[any]any{
 				"limit": 4,

--- a/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
@@ -101,9 +101,9 @@ func (s *GetExperimentRunsTestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
-			require.Nil(t, s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s/runs", tt.ID))
+			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s/runs", tt.ID))
 			assert.Equal(s.T(), tt.error, resp.Error())
 		})
 	}

--- a/tests/integration/golang/aim/experiment/get_experiment_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_test.go
@@ -104,9 +104,9 @@ func (s *GetExperimentTestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
-			require.Nil(t, s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s", tt.ID))
+			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s", tt.ID))
 			assert.Equal(s.T(), tt.error, resp.Error())
 		})
 	}

--- a/tests/integration/golang/aim/metric/search_aligned_test.go
+++ b/tests/integration/golang/aim/metric/search_aligned_test.go
@@ -736,7 +736,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
 			require.Nil(s.T(), s.AIMClient().WithMethod(
 				http.MethodPost,

--- a/tests/integration/golang/aim/metric/search_test.go
+++ b/tests/integration/golang/aim/metric/search_test.go
@@ -5878,7 +5878,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/namespace/flows/app_test.go
+++ b/tests/integration/golang/aim/namespace/flows/app_test.go
@@ -56,7 +56,7 @@ func (s *AppFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer func() {
 				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			}()

--- a/tests/integration/golang/aim/namespace/flows/dashboard_test.go
+++ b/tests/integration/golang/aim/namespace/flows/dashboard_test.go
@@ -57,7 +57,7 @@ func (s *DashboardFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer func() {
 				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 			}()

--- a/tests/integration/golang/aim/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/aim/namespace/flows/experiment_test.go
@@ -88,7 +88,7 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/aim/namespace/flows/metric_test.go
+++ b/tests/integration/golang/aim/namespace/flows/metric_test.go
@@ -89,7 +89,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/aim/namespace/flows/project_test.go
+++ b/tests/integration/golang/aim/namespace/flows/project_test.go
@@ -86,7 +86,7 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/aim/namespace/flows/run_test.go
+++ b/tests/integration/golang/aim/namespace/flows/run_test.go
@@ -96,7 +96,7 @@ func (s *RunFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/aim/namespace/namespace_test.go
+++ b/tests/integration/golang/aim/namespace/namespace_test.go
@@ -47,7 +47,7 @@ func (s *NamespaceTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/run/archive_batch_test.go
+++ b/tests/integration/golang/aim/run/archive_batch_test.go
@@ -79,7 +79,7 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
@@ -137,7 +137,7 @@ func (s *ArchiveBatchTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)

--- a/tests/integration/golang/aim/run/delete_batch_test.go
+++ b/tests/integration/golang/aim/run/delete_batch_test.go
@@ -70,7 +70,7 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
@@ -119,7 +119,7 @@ func (s *DeleteBatchTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)

--- a/tests/integration/golang/aim/run/delete_test.go
+++ b/tests/integration/golang/aim/run/delete_test.go
@@ -76,7 +76,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(),
 				s.runs[0].ExperimentID,
@@ -123,7 +123,7 @@ func (s *DeleteRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -62,7 +62,7 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.GetRunInfo
 			require.Nil(
 				s.T(),
@@ -96,7 +96,7 @@ func (s *GetRunInfoTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID))
 			assert.Equal(s.T(), "Not Found", resp.Message)

--- a/tests/integration/golang/aim/run/get_run_metrics_test.go
+++ b/tests/integration/golang/aim/run/get_run_metrics_test.go
@@ -89,7 +89,7 @@ func (s *GetRunMetricsTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.GetRunMetrics
 			require.Nil(
 				s.T(),
@@ -124,7 +124,7 @@ func (s *GetRunMetricsTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -75,7 +75,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			if tt.beforeRunFn != nil {
 				tt.beforeRunFn()
 			}

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -772,7 +772,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/aim/run/update_run_test.go
+++ b/tests/integration/golang/aim/run/update_run_test.go
@@ -68,7 +68,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Success
 			require.Nil(
 				s.T(),
@@ -118,7 +118,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			var resp response.Error
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
@@ -77,7 +77,7 @@ func (s *GetArtifactGSTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			// create test experiment
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
@@ -269,9 +269,9 @@ func (s *GetArtifactGSTestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(t, s.MlflowClient().WithQuery(
+			require.Nil(s.T(), s.MlflowClient().WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,

--- a/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
@@ -60,9 +60,9 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			// 1. create test experiment.
-			experimentArtifactDir := t.TempDir()
+			experimentArtifactDir := s.T().TempDir()
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Path %s", experimentArtifactDir),
 				NamespaceID:      namespace.ID,
@@ -252,9 +252,9 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(t, s.MlflowClient().WithQuery(
+			require.Nil(s.T(), s.MlflowClient().WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -77,7 +77,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			// create test experiment
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
@@ -274,9 +274,9 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(t, s.MlflowClient().WithQuery(
+			require.Nil(s.T(), s.MlflowClient().WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,

--- a/tests/integration/golang/mlflow/artifact/list_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_gs_test.go
@@ -79,7 +79,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			// 1. create test experiment.
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name: fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
@@ -125,7 +125,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			)
 			_, err = writer.Write([]byte("contentX"))
 			require.Nil(s.T(), err)
-			require.Nil(t, writer.Close())
+			require.Nil(s.T(), writer.Close())
 
 			writer = s.gsClient.Bucket(
 				tt.bucket,
@@ -136,7 +136,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			)
 			_, err = writer.Write([]byte("contentXX"))
 			require.Nil(s.T(), err)
-			require.Nil(t, writer.Close())
+			require.Nil(s.T(), writer.Close())
 
 			// 4. make actual API call for root dir.
 			rootDirQuery := request.ListArtifactsRequest{
@@ -289,7 +289,7 @@ func (s *ListArtifactGSTestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),
@@ -301,7 +301,7 @@ func (s *ListArtifactGSTestSuite) Test_Error() {
 					"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsListRoute,
 				),
 			)
-			require.Nil(t, err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.error.Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/artifact/list_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_local_test.go
@@ -62,9 +62,9 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			// 1. create test experiment.
-			experimentArtifactDir := t.TempDir()
+			experimentArtifactDir := s.T().TempDir()
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name: fmt.Sprintf("Test Experiment In Path %s", experimentArtifactDir),
 				Tags: []models.ExperimentTag{
@@ -262,7 +262,7 @@ func (s *ListArtifactLocalTestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(s.T(), s.MlflowClient().WithQuery(
 				tt.request,

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -82,7 +82,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			// 1. create test experiment.
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name: fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
@@ -282,7 +282,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),
@@ -294,7 +294,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 					"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsListRoute,
 				),
 			)
-			require.Nil(t, err)
+			require.Nil(s.T(), err)
 			assert.Equal(s.T(), tt.error.Error(), resp.Error())
 		})
 	}

--- a/tests/integration/golang/mlflow/experiment/create_test.go
+++ b/tests/integration/golang/mlflow/experiment/create_test.go
@@ -106,7 +106,7 @@ func (s *CreateExperimentTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/delete_test.go
+++ b/tests/integration/golang/mlflow/experiment/delete_test.go
@@ -139,7 +139,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/get_by_name_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_by_name_test.go
@@ -129,7 +129,7 @@ func (s *GetExperimentByNameTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/get_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_test.go
@@ -134,7 +134,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/restore_test.go
+++ b/tests/integration/golang/mlflow/experiment/restore_test.go
@@ -137,7 +137,7 @@ func (s *RestoreExperimentTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/search_test.go
+++ b/tests/integration/golang/mlflow/experiment/search_test.go
@@ -161,7 +161,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := response.SearchExperimentsResponse{}
 			require.Nil(
 				s.T(),
@@ -179,7 +179,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 				names[i] = exp.Name
 			}
 
-			assert.ElementsMatch(t, tt.expected, names)
+			assert.ElementsMatch(s.T(), tt.expected, names)
 		})
 	}
 }
@@ -272,7 +272,7 @@ func (s *SearchExperimentsTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
+++ b/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
@@ -224,7 +224,7 @@ func (s *SetExperimentTagTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/experiment/update_test.go
+++ b/tests/integration/golang/mlflow/experiment/update_test.go
@@ -127,7 +127,7 @@ func (s *UpdateExperimentTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -109,7 +109,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
 			require.Nil(
 				s.T(),
@@ -179,7 +179,7 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -166,7 +166,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -126,7 +126,7 @@ func (s *GetHistoryTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/namespace/flows/artifact_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/artifact_test.go
@@ -101,7 +101,7 @@ func (s *ArtifactFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer func() {
 				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 				require.Nil(s.T(), helpers.RemoveS3Buckets(s.s3Client, s.testBuckets))

--- a/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
@@ -99,7 +99,7 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 	// default namespace and experiment, so it could lead to the problems with actual tests.
 	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/mlflow/namespace/flows/metric_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/metric_test.go
@@ -89,7 +89,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/mlflow/namespace/flows/run_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/run_test.go
@@ -98,7 +98,7 @@ func (s *RunFlowTestSuite) Test_Ok() {
 	}
 
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.

--- a/tests/integration/golang/mlflow/namespace/namespace_test.go
+++ b/tests/integration/golang/mlflow/namespace/namespace_test.go
@@ -49,7 +49,7 @@ func (s *NamespaceTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -272,7 +272,7 @@ func (s *CreateRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			client := s.MlflowClient().WithMethod(
 				http.MethodPost,

--- a/tests/integration/golang/mlflow/run/delete_tag_test.go
+++ b/tests/integration/golang/mlflow/run/delete_tag_test.go
@@ -194,7 +194,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/delete_test.go
+++ b/tests/integration/golang/mlflow/run/delete_test.go
@@ -70,7 +70,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := map[string]any{}
 			require.Nil(
 				s.T(),
@@ -89,7 +89,7 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 			archivedRuns, err := s.RunFixtures.GetRuns(context.Background(), run.ExperimentID)
 
 			require.Nil(s.T(), err)
-			assert.Equal(T, 1, len(archivedRuns))
+			assert.Equal(s.T(), 1, len(archivedRuns))
 			assert.Equal(s.T(), run.ID, archivedRuns[0].ID)
 			assert.Equal(s.T(), models.LifecycleStageDeleted, archivedRuns[0].LifecycleStage)
 		})
@@ -118,7 +118,7 @@ func (s *DeleteRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -176,7 +176,7 @@ func (s *GetRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -76,7 +76,7 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := map[string]any{}
 			require.Nil(
 				s.T(),
@@ -177,7 +177,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := map[string]any{}
 			require.Nil(
 				s.T(),
@@ -355,7 +355,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			// do actual call to API.
 			resp := map[string]any{}
 			require.Nil(
@@ -444,7 +444,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 	}
 
 	for _, tt := range testData {
-		s.T().Run(tt.name, func(t *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -202,7 +202,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			// if setupDatabase has been provided then configure database with test data.
 			if tt.setupDatabase != nil {
 				if runID := tt.setupDatabase(); runID != "" {

--- a/tests/integration/golang/mlflow/run/restore_test.go
+++ b/tests/integration/golang/mlflow/run/restore_test.go
@@ -146,7 +146,7 @@ func (s *RestoreRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/search_test.go
+++ b/tests/integration/golang/mlflow/run/search_test.go
@@ -2944,7 +2944,7 @@ func (s *SearchTestSuite) testCases(
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := &response.SearchRunsResponse{}
 			client := s.MlflowClient().WithMethod(
 				http.MethodPost,

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -145,7 +145,7 @@ func (s *SetRunTagTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),

--- a/tests/integration/golang/mlflow/run/update_test.go
+++ b/tests/integration/golang/mlflow/run/update_test.go
@@ -140,7 +140,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 		},
 	}
 	for _, tt := range tests {
-		s.T().Run(tt.name, func(T *testing.T) {
+		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
 			require.Nil(
 				s.T(),


### PR DESCRIPTION
This PR fixes the way we launch subtests by using the actual the testfify framework correctly, allowing us to introduce setup/teardown for the subtests in subsequent PRs.