### PR TITLE
Fix timestamp types in Aim integration tests

### DIFF
--- a/pkg/api/aim/response/run.go
+++ b/pkg/api/aim/response/run.go
@@ -22,13 +22,12 @@ type GetRunInfoTraces struct {
 
 // GetRunInfoProps run properties
 type GetRunInfoProps struct {
-	ID           string               `json:"id"`
 	Name         string               `json:"name"`
 	Description  string               `json:"description"`
 	Experiment   GetRunInfoExperiment `json:"experiment"`
 	Tags         []string             `json:"tags"`
-	CreationTime int64                `json:"creation_time"`
-	EndTime      int64                `json:"end_time"`
+	CreationTime float64              `json:"creation_time"`
+	EndTime      float64              `json:"end_time"`
 	Archived     bool                 `json:"archived"`
 	Active       bool                 `json:"active"`
 }

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -70,9 +70,8 @@ func (s *CreateAppTestSuite) Test_Ok() {
 			assert.Equal(s.T(), tt.requestBody.Type, resp.Type)
 			assert.Equal(s.T(), tt.requestBody.State["app-state-key"], resp.State["app-state-key"])
 			assert.NotEmpty(s.T(), resp.ID)
-			// TODO these timestamps are not set by the create endpoint
-			// assert.NotEmpty(s.T(), resp.CreatedAt)
-			// assert.NotEmpty(s.T(), resp.UpdatedAt)
+			assert.NotEmpty(s.T(), resp.CreatedAt)
+			assert.NotEmpty(s.T(), resp.UpdatedAt)
 		})
 	}
 }

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -62,9 +62,8 @@ func (s *GetAppsTestSuite) Test_Ok() {
 				assert.Equal(s.T(), apps[idx].ID.String(), resp[idx].ID)
 				assert.Equal(s.T(), apps[idx].Type, resp[idx].Type)
 				assert.Equal(s.T(), apps[idx].State, database.AppState(resp[idx].State))
-				// TODO these timestamps are not populated by the endpoint -- should they be?
-				// assert.NotEmpty(s.T(), resp[idx].CreatedAt)
-				// assert.NotEmpty(s.T(), resp[idx].UpdatedAt)
+				assert.NotEmpty(s.T(), resp[idx].CreatedAt)
+				assert.NotEmpty(s.T(), resp[idx].UpdatedAt)
 			}
 		})
 	}

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -68,16 +68,12 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 				s.T(),
 				s.AIMClient().WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID),
 			)
-			// TODO this assertion fails because ID is not rendered by the endpoint
-			// assert.Equal(s.T(), s.run.ID, resp.Props.ID)
 			assert.Equal(s.T(), s.run.Name, resp.Props.Name)
 			assert.Equal(s.T(), fmt.Sprintf("%v", s.run.ExperimentID), resp.Props.Experiment.ID)
-			assert.Equal(s.T(), s.run.StartTime.Int64, resp.Props.CreationTime)
-			assert.Equal(s.T(), s.run.EndTime.Int64, resp.Props.EndTime)
+			assert.Equal(s.T(), float64(s.run.StartTime.Int64)/1000, resp.Props.CreationTime)
+			assert.Equal(s.T(), float64(s.run.EndTime.Int64)/1000, resp.Props.EndTime)
 			// TODO this assertion fails because tags are not rendered by endpoint
 			// assert.Equal(s.T(), s.run.Tags[0].Key, resp.Props.Tags[0])
-			// TODO this assertion fails so maybe the endpoint is not populating correctly
-			// assert.NotEmpty(s.T(), resp.Props.CreationTime)
 		})
 	}
 }

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -105,8 +105,8 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 					assert.Equal(s.T(), fmt.Sprintf("%v", run.ExperimentID), decodedData[expIdKey])
 					assert.Equal(s.T(), run.Status == models.StatusRunning, decodedData[activeKey])
 					assert.Equal(s.T(), false, decodedData[archivedKey])
-					assert.Equal(s.T(), run.StartTime.Int64, int64(decodedData[startTimeKey].(float64)))
-					assert.Equal(s.T(), run.EndTime.Int64, int64(decodedData[endTimeKey].(float64)))
+					assert.Equal(s.T(), float64(run.StartTime.Int64)/1000, decodedData[startTimeKey])
+					assert.Equal(s.T(), float64(run.EndTime.Int64)/1000, decodedData[endTimeKey])
 					responseCount++
 				} else {
 					assert.Nil(s.T(), decodedData[respNameKey])


### PR DESCRIPTION
This PR corrects the types used by timestamps in our Aim integration tests. We were incorrectly using integers whilst the API is returning floats. A couple of disabled assertions are also enabled.