### PR TITLE
Use a consistent test style in migration tests

### DIFF
--- a/tests/integration/golang/database/migrate_test.go
+++ b/tests/integration/golang/database/migrate_test.go
@@ -11,37 +11,58 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/database"
 )
 
-func TestMigrate(t *testing.T) {
-	testMigrateWithSchema(t, "mlflow-c48cb773bb87-v1.16.0.sql")
-	testMigrateWithSchema(t, "mlflow-7f2a7d5fae7d-v2.8.0.sql")
+type MigrateTestSuite struct {
+	suite.Suite
 }
 
-func testMigrateWithSchema(t *testing.T, schema string) {
-	// setup sqlite MLFlow database from the schema
-	mlflowDBPath := path.Join(t.TempDir(), "mlflow.db")
-	mlflowDB, err := sql.Open("sqlite3", mlflowDBPath)
-	require.Nil(t, err)
+func TestMigrateTestSuite(t *testing.T) {
+	suite.Run(t, new(MigrateTestSuite))
+}
 
-	//nolint:gosec
-	mlflowSql, err := os.ReadFile(schema)
-	require.Nil(t, err)
+func (s *MigrateTestSuite) TestMigrate() {
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{
+			name:   "MigrateFromMLFlow2.8.0",
+			schema: "mlflow-7f2a7d5fae7d-v2.8.0.sql",
+		},
+		{
+			name:   "MigrateFromMLFlow1.16.0",
+			schema: "mlflow-c48cb773bb87-v1.16.0.sql",
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			// setup sqlite MLFlow database from the schema
+			mlflowDBPath := path.Join(s.T().TempDir(), "mlflow.db")
+			mlflowDB, err := sql.Open("sqlite3", mlflowDBPath)
+			require.Nil(s.T(), err)
 
-	_, err = mlflowDB.Exec(string(mlflowSql))
-	require.Nil(t, err)
-	require.Nil(t, mlflowDB.Close())
+			//nolint:gosec
+			mlflowSql, err := os.ReadFile(tt.schema)
+			require.Nil(s.T(), err)
 
-	// make DbProvider using our package
-	db, err := database.NewDBProvider(
-		fmt.Sprintf("sqlite://%s", mlflowDBPath),
-		1*time.Second,
-		20,
-	)
-	require.Nil(t, err)
+			_, err = mlflowDB.Exec(string(mlflowSql))
+			require.Nil(s.T(), err)
+			require.Nil(s.T(), mlflowDB.Close())
 
-	// run migrations
-	require.Nil(t, database.CheckAndMigrateDB(true, db.GormDB()))
+			// make DbProvider using our package
+			db, err := database.NewDBProvider(
+				fmt.Sprintf("sqlite://%s", mlflowDBPath),
+				1*time.Second,
+				20,
+			)
+			require.Nil(s.T(), err)
+
+			// run migrations
+			require.Nil(s.T(), database.CheckAndMigrateDB(true, db.GormDB()))
+		})
+	}
 }


### PR DESCRIPTION
This PR improves the migration tests to use the same style as all our other tests: using a test suite and sub tests.
This means that if one migration fails but not the others, we will see it in the results, instead of having the entire test fail and not try the other migration(s).