### PR TITLE
Use assert and require in a more idiomatic way in our tests

### DIFF
--- a/tests/integration/golang/admin/namespace/create_test.go
+++ b/tests/integration/golang/admin/namespace/create_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -28,14 +26,14 @@ func TestCreateNamespaceTestSuite(t *testing.T) {
 
 func (s *CreateNamespaceTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	requests := []request.Namespace{
 		{
@@ -48,8 +46,7 @@ func (s *CreateNamespaceTestSuite) Test_Ok() {
 		},
 	}
 	for _, request := range requests {
-		require.Nil(
-			s.T(),
+		s.Require().Nil(
 			s.AdminClient().WithMethod(
 				http.MethodPost,
 			).WithRequest(
@@ -59,23 +56,23 @@ func (s *CreateNamespaceTestSuite) Test_Ok() {
 	}
 
 	namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-	require.Nil(s.T(), err)
-	assert.True(s.T(), helpers.CheckNamespaces(namespaces, requests))
+	s.Require().Nil(err)
+	s.True(helpers.CheckNamespaces(namespaces, requests))
 
 	// Check the length of the namespaces considering the default namespace
-	assert.Equal(s.T(), len(requests)+1, len(namespaces))
+	s.Equal(len(requests)+1, len(namespaces))
 }
 
 func (s *CreateNamespaceTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -126,8 +123,7 @@ func (s *CreateNamespaceTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			var resp goquery.Document
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AdminClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -140,13 +136,13 @@ func (s *CreateNamespaceTestSuite) Test_Error() {
 			)
 
 			msg := resp.Find(".error-message").Text()
-			assert.Equal(s.T(), tt.error, msg)
+			s.Equal(tt.error, msg)
 
 			namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// Check that creation failed, only the default namespace is present
-			assert.Equal(s.T(), 1, len(namespaces))
+			s.Equal(1, len(namespaces))
 		})
 	}
 }

--- a/tests/integration/golang/admin/namespace/delete_test.go
+++ b/tests/integration/golang/admin/namespace/delete_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -26,28 +24,28 @@ func TestDeleteNamespaceTestSuite(t *testing.T) {
 
 func (s *DeleteNamespaceTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	ns2, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  3,
 		Code:                "test3",
 		Description:         "test namespace 3 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name                   string
@@ -60,8 +58,7 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AdminClient().WithMethod(
 					http.MethodDelete,
 				).DoRequest(
@@ -69,29 +66,29 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 				),
 			)
 			namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedNamespaceCount, len(namespaces))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedNamespaceCount, len(namespaces))
 		})
 	}
 }
 
 func (s *DeleteNamespaceTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name                    string
@@ -112,8 +109,7 @@ func (s *DeleteNamespaceTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			var resp any
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AdminClient().WithMethod(
 					http.MethodDelete,
 				).WithResponse(
@@ -122,11 +118,11 @@ func (s *DeleteNamespaceTestSuite) Test_Error() {
 					"/namespaces/%s", tt.ID,
 				),
 			)
-			assert.Equal(s.T(), resp, tt.response)
+			s.Equal(resp, tt.response)
 		})
 		namespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-		require.Nil(s.T(), err)
+		s.Require().Nil(err)
 		// Check that deletion failed and the namespace is still there
-		assert.Equal(s.T(), tt.expectedNamespacesCount, len(namespaces))
+		s.Equal(tt.expectedNamespacesCount, len(namespaces))
 	}
 }

--- a/tests/integration/golang/admin/namespace/update_test.go
+++ b/tests/integration/golang/admin/namespace/update_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -27,28 +25,27 @@ func TestUpdateNamespaceTestSuite(t *testing.T) {
 
 func (s *UpdateNamespaceTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	ns, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	request := request.Namespace{
 		Code:        "test2Updated",
 		Description: "test namespace 2 description updated",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AdminClient().WithMethod(
 			http.MethodPut,
 		).WithRequest(
@@ -57,31 +54,31 @@ func (s *UpdateNamespaceTestSuite) Test_Ok() {
 	)
 
 	namespace, err := s.NamespaceFixtures.GetNamespaceByID(context.Background(), ns.ID)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
-	assert.Equal(s.T(), namespace.Code, request.Code)
-	assert.Equal(s.T(), namespace.Description, request.Description)
+	s.Equal(namespace.Code, request.Code)
+	s.Equal(namespace.Description, request.Description)
 }
 
 func (s *UpdateNamespaceTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	expectedNamespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name     string
@@ -129,8 +126,7 @@ func (s *UpdateNamespaceTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			var resp any
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AdminClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -141,10 +137,10 @@ func (s *UpdateNamespaceTestSuite) Test_Error() {
 					"/namespaces/%s", tt.ID,
 				),
 			)
-			assert.Equal(s.T(), resp, tt.response)
+			s.Equal(resp, tt.response)
 		})
 		actualNamespaces, err := s.NamespaceFixtures.GetNamespaces(context.Background())
-		require.Nil(s.T(), err)
-		assert.Equal(s.T(), expectedNamespaces, actualNamespaces)
+		s.Require().Nil(err)
+		s.Equal(expectedNamespaces, actualNamespaces)
 	}
 }

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -28,7 +26,7 @@ func TestCreateAppTestSuite(t *testing.T) {
 
 func (s *CreateAppTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -36,7 +34,7 @@ func (s *CreateAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -55,8 +53,7 @@ func (s *CreateAppTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.App
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -67,18 +64,18 @@ func (s *CreateAppTestSuite) Test_Ok() {
 					"/apps",
 				),
 			)
-			assert.Equal(s.T(), tt.requestBody.Type, resp.Type)
-			assert.Equal(s.T(), tt.requestBody.State["app-state-key"], resp.State["app-state-key"])
-			assert.NotEmpty(s.T(), resp.ID)
-			assert.NotEmpty(s.T(), resp.CreatedAt)
-			assert.NotEmpty(s.T(), resp.UpdatedAt)
+			s.Equal(tt.requestBody.Type, resp.Type)
+			s.Equal(tt.requestBody.State["app-state-key"], resp.State["app-state-key"])
+			s.NotEmpty(resp.ID)
+			s.NotEmpty(resp.CreatedAt)
+			s.NotEmpty(resp.UpdatedAt)
 		})
 	}
 }
 
 func (s *CreateAppTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -86,7 +83,7 @@ func (s *CreateAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -102,8 +99,7 @@ func (s *CreateAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -112,7 +108,7 @@ func (s *CreateAppTestSuite) Test_Error() {
 					&resp,
 				).DoRequest("/apps"),
 			)
-			assert.Contains(s.T(), resp.Message, "cannot unmarshal")
+			s.Contains(resp.Message, "cannot unmarshal")
 		})
 	}
 }

--- a/tests/integration/golang/aim/app/delete_app_test.go
+++ b/tests/integration/golang/aim/app/delete_app_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -30,7 +28,7 @@ func TestDeleteAppTestSuite(t *testing.T) {
 
 func (s *DeleteAppTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,7 +36,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -49,7 +47,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name             string
@@ -62,8 +60,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodDelete,
 				).DoRequest(
@@ -71,15 +68,15 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 				),
 			)
 			apps, err := s.AppFixtures.GetApps(context.Background())
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedAppCount, len(apps))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedAppCount, len(apps))
 		})
 	}
 }
 
 func (s *DeleteAppTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -87,7 +84,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -98,7 +95,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name             string
@@ -114,8 +111,7 @@ func (s *DeleteAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodDelete,
 				).WithResponse(
@@ -124,11 +120,11 @@ func (s *DeleteAppTestSuite) Test_Error() {
 					"/apps/%s", tt.idParam,
 				),
 			)
-			assert.Contains(s.T(), resp.Message, "Not Found")
+			s.Contains(resp.Message, "Not Found")
 
 			apps, err := s.AppFixtures.GetApps(context.Background())
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedAppCount, len(apps))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedAppCount, len(apps))
 		})
 	}
 }

--- a/tests/integration/golang/aim/app/get_app_test.go
+++ b/tests/integration/golang/aim/app/get_app_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -29,7 +27,7 @@ func TestGetAppTestSuite(t *testing.T) {
 
 func (s *GetAppTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -37,7 +35,7 @@ func (s *GetAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -48,20 +46,20 @@ func (s *GetAppTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp database.App
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/apps/%s", app.ID.String()))
-	assert.Equal(s.T(), app.ID, resp.ID)
-	assert.Equal(s.T(), app.Type, resp.Type)
-	assert.Equal(s.T(), app.State, resp.State)
-	assert.NotEmpty(s.T(), resp.CreatedAt)
-	assert.NotEmpty(s.T(), resp.UpdatedAt)
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/apps/%s", app.ID.String()))
+	s.Equal(app.ID, resp.ID)
+	s.Equal(app.Type, resp.Type)
+	s.Equal(app.State, resp.State)
+	s.NotEmpty(resp.CreatedAt)
+	s.NotEmpty(resp.UpdatedAt)
 }
 
 func (s *GetAppTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -69,7 +67,7 @@ func (s *GetAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -83,8 +81,8 @@ func (s *GetAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/apps/%v", tt.idParam))
-			assert.Equal(s.T(), "Not Found", resp.Message)
+			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/apps/%v", tt.idParam))
+			s.Equal("Not Found", resp.Message)
 		})
 	}
 }

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -42,7 +40,7 @@ func (s *GetAppsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			defer func() {
-				require.Nil(s.T(), s.AppFixtures.UnloadFixtures())
+				s.Require().Nil(s.AppFixtures.UnloadFixtures())
 			}()
 
 			namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -50,20 +48,20 @@ func (s *GetAppsTestSuite) Test_Ok() {
 				Code:                "default",
 				DefaultExperimentID: common.GetPointer(int32(0)),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			apps, err := s.AppFixtures.CreateApps(context.Background(), namespace, tt.expectedAppCount)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			var resp []response.App
-			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/apps"))
-			assert.Equal(s.T(), tt.expectedAppCount, len(resp))
+			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/apps"))
+			s.Equal(tt.expectedAppCount, len(resp))
 			for idx := 0; idx < tt.expectedAppCount; idx++ {
-				assert.Equal(s.T(), apps[idx].ID.String(), resp[idx].ID)
-				assert.Equal(s.T(), apps[idx].Type, resp[idx].Type)
-				assert.Equal(s.T(), apps[idx].State, database.AppState(resp[idx].State))
-				assert.NotEmpty(s.T(), resp[idx].CreatedAt)
-				assert.NotEmpty(s.T(), resp[idx].UpdatedAt)
+				s.Equal(apps[idx].ID.String(), resp[idx].ID)
+				s.Equal(apps[idx].Type, resp[idx].Type)
+				s.Equal(apps[idx].State, database.AppState(resp[idx].State))
+				s.NotEmpty(resp[idx].CreatedAt)
+				s.NotEmpty(resp[idx].UpdatedAt)
 			}
 		})
 	}

--- a/tests/integration/golang/aim/app/update_app_test.go
+++ b/tests/integration/golang/aim/app/update_app_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -31,7 +29,7 @@ func TestUpdateAppTestSuite(t *testing.T) {
 
 func (s *UpdateAppTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -39,7 +37,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -50,7 +48,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -69,8 +67,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.App
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -81,8 +78,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 					"/apps/%s", app.ID,
 				),
 			)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -93,15 +89,15 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 					"/apps/%s", app.ID,
 				),
 			)
-			assert.Equal(s.T(), "app-type", resp.Type)
-			assert.Equal(s.T(), response.AppState{"app-state-key": "new-app-state-value"}, resp.State)
+			s.Equal("app-type", resp.Type)
+			s.Equal(response.AppState{"app-state-key": "new-app-state-value"}, resp.State)
 		})
 	}
 }
 
 func (s *UpdateAppTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -109,7 +105,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -120,7 +116,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -146,8 +142,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -158,7 +153,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 					"/apps/%s", tt.ID,
 				),
 			)
-			assert.Contains(s.T(), resp.Message, tt.error)
+			s.Contains(resp.Message, tt.error)
 		})
 	}
 }

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -31,7 +29,7 @@ func TestCreateDashboardTestSuite(t *testing.T) {
 
 func (s *CreateDashboardTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -39,7 +37,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -51,7 +49,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -69,8 +67,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Dashboard
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -81,21 +78,21 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 			)
 
 			dashboards, err := s.DashboardFixtures.GetDashboards(context.Background())
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.requestBody.Name, resp.Name)
-			assert.Equal(s.T(), tt.requestBody.Description, resp.Description)
-			assert.Equal(s.T(), dashboards[0].Name, resp.Name)
-			assert.Equal(s.T(), dashboards[0].Description, resp.Description)
-			assert.Equal(s.T(), dashboards[0].ID.String(), resp.ID)
-			assert.Equal(s.T(), dashboards[0].AppID, &resp.AppID)
-			assert.NotEmpty(s.T(), resp.ID)
+			s.Require().Nil(err)
+			s.Equal(tt.requestBody.Name, resp.Name)
+			s.Equal(tt.requestBody.Description, resp.Description)
+			s.Equal(dashboards[0].Name, resp.Name)
+			s.Equal(dashboards[0].Description, resp.Description)
+			s.Equal(dashboards[0].ID.String(), resp.ID)
+			s.Equal(dashboards[0].AppID, &resp.AppID)
+			s.NotEmpty(resp.ID)
 		})
 	}
 }
 
 func (s *CreateDashboardTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -103,7 +100,7 @@ func (s *CreateDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -121,8 +118,7 @@ func (s *CreateDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -131,7 +127,7 @@ func (s *CreateDashboardTestSuite) Test_Error() {
 					&resp,
 				).DoRequest("/dashboards"),
 			)
-			assert.Contains(s.T(), resp.Message, "Not Found")
+			s.Contains(resp.Message, "Not Found")
 		})
 	}
 }

--- a/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -30,7 +28,7 @@ func TestDeleteDashboardTestSuite(t *testing.T) {
 
 func (s *DeleteDashboardTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,7 +36,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -50,7 +48,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -62,7 +60,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name                   string
@@ -76,8 +74,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodDelete,
 				).WithResponse(
@@ -87,15 +84,15 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 				),
 			)
 			dashboards, err := s.DashboardFixtures.GetDashboards(context.Background())
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedDashboardCount, len(dashboards))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedDashboardCount, len(dashboards))
 		})
 	}
 }
 
 func (s *DeleteDashboardTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -103,7 +100,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -115,7 +112,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -127,7 +124,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name                   string
@@ -143,8 +140,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodDelete,
 				).WithResponse(
@@ -153,11 +149,11 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 					"/dashboards/%s", tt.idParam,
 				),
 			)
-			assert.Contains(s.T(), resp.Message, "Not Found")
+			s.Contains(resp.Message, "Not Found")
 
 			dashboards, err := s.DashboardFixtures.GetDashboards(context.Background())
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedDashboardCount, len(dashboards))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedDashboardCount, len(dashboards))
 		})
 	}
 }

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -29,7 +27,7 @@ func TestGetDashboardTestSuite(t *testing.T) {
 
 func (s *GetDashboardTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -37,7 +35,7 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -49,7 +47,7 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -61,21 +59,21 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp database.Dashboard
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/dashboards/%s", dashboard.ID))
-	assert.Equal(s.T(), dashboard.ID, resp.ID)
-	assert.Equal(s.T(), &app.ID, resp.AppID)
-	assert.Equal(s.T(), dashboard.Name, resp.Name)
-	assert.Equal(s.T(), dashboard.Description, resp.Description)
-	assert.NotEmpty(s.T(), resp.CreatedAt)
-	assert.NotEmpty(s.T(), resp.UpdatedAt)
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/dashboards/%s", dashboard.ID))
+	s.Equal(dashboard.ID, resp.ID)
+	s.Equal(&app.ID, resp.AppID)
+	s.Equal(dashboard.Name, resp.Name)
+	s.Equal(dashboard.Description, resp.Description)
+	s.NotEmpty(resp.CreatedAt)
+	s.NotEmpty(resp.UpdatedAt)
 }
 
 func (s *GetDashboardTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -83,7 +81,7 @@ func (s *GetDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -97,11 +95,10 @@ func (s *GetDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithResponse(&resp).DoRequest("/dashboards/%s", tt.idParam),
 			)
-			assert.Equal(s.T(), "Not Found", resp.Message)
+			s.Equal("Not Found", resp.Message)
 		})
 	}
 }

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -44,7 +42,7 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			defer func() {
-				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			}()
 
 			namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -52,7 +50,7 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 				Code:                "default",
 				DefaultExperimentID: common.GetPointer(int32(0)),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 				Base: database.Base{
@@ -64,23 +62,23 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 				State:       database.AppState{},
 				NamespaceID: namespace.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			dashboards, err := s.DashboardFixtures.CreateDashboards(
 				context.Background(), tt.expectedDashboardCount, &app.ID,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			var resp []response.Dashboard
-			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/dashboards"))
-			assert.Equal(s.T(), tt.expectedDashboardCount, len(resp))
+			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/dashboards"))
+			s.Equal(tt.expectedDashboardCount, len(resp))
 			for idx := 0; idx < tt.expectedDashboardCount; idx++ {
-				assert.Equal(s.T(), dashboards[idx].ID.String(), resp[idx].ID)
-				assert.Equal(s.T(), app.ID, resp[idx].AppID)
-				assert.Equal(s.T(), dashboards[idx].Name, resp[idx].Name)
-				assert.Equal(s.T(), dashboards[idx].Description, resp[idx].Description)
-				assert.NotEmpty(s.T(), resp[idx].CreatedAt)
-				assert.NotEmpty(s.T(), resp[idx].UpdatedAt)
+				s.Equal(dashboards[idx].ID.String(), resp[idx].ID)
+				s.Equal(app.ID, resp[idx].AppID)
+				s.Equal(dashboards[idx].Name, resp[idx].Name)
+				s.Equal(dashboards[idx].Description, resp[idx].Description)
+				s.NotEmpty(resp[idx].CreatedAt)
+				s.NotEmpty(resp[idx].UpdatedAt)
 			}
 		})
 	}

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -31,7 +29,7 @@ func TestUpdateDashboardTestSuite(t *testing.T) {
 
 func (s *UpdateDashboardTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -39,7 +37,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -51,7 +49,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -63,7 +61,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -80,8 +78,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Dashboard
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -92,8 +89,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 					"/dashboards/%s", dashboard.ID,
 				),
 			)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -107,19 +103,19 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 
 			actualDashboard, err := s.DashboardFixtures.GetDashboardByID(context.Background(), dashboard.ID.String())
 
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.requestBody.Name, resp.Name)
-			assert.Equal(s.T(), tt.requestBody.Description, resp.Description)
-			assert.Equal(s.T(), (dashboard.ID).String(), resp.ID)
-			assert.Equal(s.T(), tt.requestBody.Name, actualDashboard.Name)
-			assert.Equal(s.T(), tt.requestBody.Description, actualDashboard.Description)
+			s.Require().Nil(err)
+			s.Equal(tt.requestBody.Name, resp.Name)
+			s.Equal(tt.requestBody.Description, resp.Description)
+			s.Equal((dashboard.ID).String(), resp.ID)
+			s.Equal(tt.requestBody.Name, actualDashboard.Name)
+			s.Equal(tt.requestBody.Description, actualDashboard.Description)
 		})
 	}
 }
 
 func (s *UpdateDashboardTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -127,7 +123,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
@@ -139,7 +135,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		State:       database.AppState{},
 		NamespaceID: namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	dashboard, err := s.DashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
 		Base: database.Base{
@@ -151,7 +147,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		AppID:       &app.ID,
 		Description: "dashboard for experiment",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name        string
@@ -176,7 +172,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(s.T(), s.AIMClient().WithMethod(
+			s.Require().Nil(s.AIMClient().WithMethod(
 				http.MethodPut,
 			).WithRequest(
 				tt.requestBody,
@@ -185,7 +181,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 			).DoRequest(
 				"/dashboards/%s", tt.ID,
 			))
-			assert.Contains(s.T(), resp.Message, tt.error)
+			s.Contains(resp.Message, tt.error)
 		})
 	}
 }

--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -30,7 +28,7 @@ func TestDeleteExperimentTestSuite(t *testing.T) {
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,7 +36,7 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -60,15 +58,14 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiments, err := s.ExperimentFixtures.GetTestExperiments(context.Background())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	length := len(experiments)
 
 	var resp response.DeleteExperiment
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodDelete,
 		).WithResponse(
@@ -79,13 +76,13 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 	)
 
 	remainingExperiments, err := s.ExperimentFixtures.GetTestExperiments(context.Background())
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), length-1, len(remainingExperiments))
+	s.Require().Nil(err)
+	s.Equal(length-1, len(remainingExperiments))
 }
 
 func (s *DeleteExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -93,7 +90,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name  string
@@ -115,8 +112,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodDelete,
 				).WithResponse(
@@ -125,8 +121,8 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 					"/experiments/%s", tt.ID,
 				),
 			)
-			assert.Contains(s.T(), resp.Error(), tt.error)
-			assert.NoError(s.T(), err)
+			s.Contains(resp.Error(), tt.error)
+			s.NoError(err)
 		})
 	}
 }

--- a/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -28,7 +26,7 @@ func TestGetExperimentRunsTestSuite(t *testing.T) {
 
 func (s *GetExperimentRunsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -36,21 +34,20 @@ func (s *GetExperimentRunsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp response.GetExperimentRuns
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithQuery(map[any]any{
 			"limit":  4,
 			"offset": runs[8].ID,
@@ -59,20 +56,20 @@ func (s *GetExperimentRunsTestSuite) Test_Ok() {
 		),
 	)
 
-	assert.Equal(s.T(), 4, len(resp.Runs))
+	s.Equal(4, len(resp.Runs))
 	for index := 0; index < len(resp.Runs); index++ {
 		r := runs[8-(index+1)]
-		assert.Equal(s.T(), r.ID, resp.Runs[index].ID)
-		assert.Equal(s.T(), r.Name, resp.Runs[index].Name)
-		assert.Equal(s.T(), float64(r.StartTime.Int64)/1000, resp.Runs[index].CreationTime)
-		assert.Equal(s.T(), float64(r.EndTime.Int64)/1000, resp.Runs[index].EndTime)
-		assert.Equal(s.T(), r.LifecycleStage == models.LifecycleStageDeleted, resp.Runs[index].Archived)
+		s.Equal(r.ID, resp.Runs[index].ID)
+		s.Equal(r.Name, resp.Runs[index].Name)
+		s.Equal(float64(r.StartTime.Int64)/1000, resp.Runs[index].CreationTime)
+		s.Equal(float64(r.EndTime.Int64)/1000, resp.Runs[index].EndTime)
+		s.Equal(r.LifecycleStage == models.LifecycleStageDeleted, resp.Runs[index].Archived)
 	}
 }
 
 func (s *GetExperimentRunsTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -80,7 +77,7 @@ func (s *GetExperimentRunsTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name  string
@@ -103,8 +100,8 @@ func (s *GetExperimentRunsTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
-			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s/runs", tt.ID))
-			assert.Equal(s.T(), tt.error, resp.Error())
+			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s/runs", tt.ID))
+			s.Equal(tt.error, resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/aim/experiment/get_experiment_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -30,7 +28,7 @@ func TestGetExperimentTestSuite(t *testing.T) {
 
 func (s *GetExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,7 +36,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -60,22 +58,22 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp response.GetExperiment
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%d", *experiment.ID))
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%d", *experiment.ID))
 
-	assert.Equal(s.T(), fmt.Sprintf("%d", *experiment.ID), resp.ID)
-	assert.Equal(s.T(), experiment.Name, resp.Name)
-	assert.Equal(s.T(), "", resp.Description)
-	assert.Equal(s.T(), float64(experiment.CreationTime.Int64)/1000, resp.CreationTime)
-	assert.Equal(s.T(), false, resp.Archived)
-	assert.Equal(s.T(), len(experiment.Runs), resp.RunCount)
+	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.ID)
+	s.Equal(experiment.Name, resp.Name)
+	s.Equal("", resp.Description)
+	s.Equal(float64(experiment.CreationTime.Int64)/1000, resp.CreationTime)
+	s.Equal(false, resp.Archived)
+	s.Equal(len(experiment.Runs), resp.RunCount)
 }
 
 func (s *GetExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -83,7 +81,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name  string
@@ -106,8 +104,8 @@ func (s *GetExperimentTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp api.ErrorResponse
-			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s", tt.ID))
-			assert.Equal(s.T(), tt.error, resp.Error())
+			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/experiments/%s", tt.ID))
+			s.Equal(tt.error, resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/aim/experiment/get_experiments_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiments_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -29,7 +27,7 @@ func TestGetExperimentsTestSuite(t *testing.T) {
 
 func (s *GetExperimentsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -37,7 +35,7 @@ func (s *GetExperimentsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiments := map[string]*models.Experiment{}
 	for i := 0; i < 5; i++ {
@@ -62,19 +60,19 @@ func (s *GetExperimentsTestSuite) Test_Ok() {
 			ArtifactLocation: "/artifact/location",
 		}
 		experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-		require.Nil(s.T(), err)
+		s.Require().Nil(err)
 		experiments[fmt.Sprintf("%d", *experiment.ID)] = experiment
 	}
 
 	var resp response.Experiments
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/experiments/"))
-	assert.Equal(s.T(), len(experiments), len(resp))
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/experiments/"))
+	s.Equal(len(experiments), len(resp))
 	for _, actualExperiment := range resp {
 		expectedExperiment := experiments[actualExperiment.ID]
-		assert.Equal(s.T(), fmt.Sprintf("%d", *expectedExperiment.ID), actualExperiment.ID)
-		assert.Equal(s.T(), expectedExperiment.Name, actualExperiment.Name)
-		assert.Equal(s.T(), float64(expectedExperiment.CreationTime.Int64)/1000, actualExperiment.CreationTime)
-		assert.Equal(s.T(), expectedExperiment.LifecycleStage == models.LifecycleStageDeleted, actualExperiment.Archived)
-		assert.Equal(s.T(), len(expectedExperiment.Runs), actualExperiment.RunCount)
+		s.Equal(fmt.Sprintf("%d", *expectedExperiment.ID), actualExperiment.ID)
+		s.Equal(expectedExperiment.Name, actualExperiment.Name)
+		s.Equal(float64(expectedExperiment.CreationTime.Int64)/1000, actualExperiment.CreationTime)
+		s.Equal(expectedExperiment.LifecycleStage == models.LifecycleStageDeleted, actualExperiment.Archived)
+		s.Equal(len(expectedExperiment.Runs), actualExperiment.RunCount)
 	}
 }

--- a/tests/integration/golang/aim/metric/search_aligned_test.go
+++ b/tests/integration/golang/aim/metric/search_aligned_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -32,14 +30,14 @@ func TestSearchAlignedMetricsTestSuite(t *testing.T) {
 
 func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -47,14 +45,14 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create different test runs and attach, metrics.
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -75,7 +73,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -85,7 +83,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric1Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -95,7 +93,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -105,7 +103,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric2Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -115,7 +113,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -125,7 +123,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric3Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -135,7 +133,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
 		Name:       "TestRun2",
@@ -154,7 +152,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -164,7 +162,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric1Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -174,7 +172,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -184,7 +182,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric2Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -194,7 +192,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -204,7 +202,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric3Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -214,7 +212,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
 		Name:       "TestRun3",
@@ -233,7 +231,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -243,7 +241,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric1Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -253,7 +251,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -263,7 +261,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric2Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -273,7 +271,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     2.6,
@@ -283,7 +281,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric3Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     2.6,
@@ -293,7 +291,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs := []*models.Run{run1, run2, run3}
 
@@ -738,7 +736,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
-			require.Nil(s.T(), s.AIMClient().WithMethod(
+			s.Require().Nil(s.AIMClient().WithMethod(
 				http.MethodPost,
 			).WithRequest(
 				tt.request,
@@ -751,7 +749,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 			))
 
 			decodedData, err := encoding.Decode(resp)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			xValues := make(map[int][]float64)
 
@@ -767,7 +765,7 @@ func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
 
 			// Check if the received values for each metric match the expected ones
 			for _, metricValues := range xValues {
-				assert.Equal(s.T(), tt.response, metricValues)
+				s.Equal(tt.response, metricValues)
 			}
 		})
 	}

--- a/tests/integration/golang/aim/metric/search_test.go
+++ b/tests/integration/golang/aim/metric/search_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -31,7 +29,7 @@ func TestSearchMetricsTestSuite(t *testing.T) {
 
 func (s *SearchMetricsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -39,7 +37,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -47,14 +45,14 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create different test runs and attach tags, metrics, params, etc.
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -75,7 +73,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -85,7 +83,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric1Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.1,
@@ -95,7 +93,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -105,7 +103,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      2,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric2Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -115,7 +113,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  2,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -125,7 +123,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		Iter:      3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric3Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -135,19 +133,19 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run1.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag1",
 		RunID: run1.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
@@ -167,7 +165,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -177,7 +175,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric1Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     0.5,
@@ -187,7 +185,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -197,7 +195,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      2,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric2Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     2.1,
@@ -207,7 +205,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  2,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -217,7 +215,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		Iter:      3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric3Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric3",
 		Value:     3.1,
@@ -227,19 +225,19 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param2",
 		Value: "value2",
 		RunID: run2.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag2",
 		RunID: run2.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
@@ -259,7 +257,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -269,7 +267,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric1Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric1",
 		Value:     1.2,
@@ -279,7 +277,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -289,7 +287,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		Iter:      4,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	metric2Run3, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric2",
 		Value:     1.6,
@@ -299,20 +297,20 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  4,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param3",
 		Value: "value3",
 		RunID: run3.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag3",
 		RunID: run3.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs := []*models.Run{run1, run2, run3}
 	tests := []struct {
@@ -5880,8 +5878,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithQuery(
 					tt.request,
 				).WithResponseType(
@@ -5891,7 +5888,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 				).DoRequest("/runs/search/metric"),
 			)
 			decodedData, err := encoding.Decode(resp)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			var decodedMetrics []*models.LatestMetric
 			for _, run := range runs {
@@ -5919,7 +5916,7 @@ func (s *SearchMetricsTestSuite) Test_Ok() {
 			}
 
 			// Check if the received metrics match the expected ones
-			assert.Equal(s.T(), tt.metrics, decodedMetrics)
+			s.Equal(tt.metrics, decodedMetrics)
 		})
 	}
 }

--- a/tests/integration/golang/aim/namespace/flows/app_test.go
+++ b/tests/integration/golang/aim/namespace/flows/app_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -29,7 +27,7 @@ func TestAppFlowTestSuite(t *testing.T) {
 }
 
 func (s *AppFlowTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *AppFlowTestSuite) Test_Ok() {
@@ -58,7 +56,7 @@ func (s *AppFlowTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			defer func() {
-				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			}()
 
 			// setup namespaces
@@ -67,7 +65,7 @@ func (s *AppFlowTestSuite) Test_Ok() {
 					Code:                nsCode,
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 			}
 
 			// run actual flow test over the test data.
@@ -97,14 +95,14 @@ func (s *AppFlowTestSuite) testAppFlow(
 	// test `GET /apps` endpoint with namespace 1
 	resp := s.getApps(namespace1Code)
 	// only app 1 should be present
-	assert.Equal(s.T(), 1, len(resp))
-	assert.Equal(s.T(), app1ID, resp[0].ID)
+	s.Equal(1, len(resp))
+	s.Equal(app1ID, resp[0].ID)
 
 	// test `GET /apps` endpoint with namespace 2
 	resp = s.getApps(namespace2Code)
 	// only app 2 should be present
-	assert.Equal(s.T(), 1, len(resp))
-	assert.Equal(s.T(), app2ID, resp[0].ID)
+	s.Equal(1, len(resp))
+	s.Equal(app2ID, resp[0].ID)
 
 	// IDs from active namespace can be fetched, updated, and deleted
 	s.getAppAndCompare(namespace1Code, app1ID)
@@ -114,8 +112,7 @@ func (s *AppFlowTestSuite) testAppFlow(
 	// IDs from other namespace cannot be fetched, updated, or deleted
 	errResp := response.Error{}
 	client := s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodGet,
 		).WithNamespace(
@@ -126,11 +123,10 @@ func (s *AppFlowTestSuite) testAppFlow(
 			fmt.Sprintf("/apps/%s", app2ID),
 		),
 	)
-	assert.Equal(s.T(), fiber.ErrNotFound.Code, client.GetStatusCode())
+	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 
 	client = s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodPut,
 		).WithNamespace(
@@ -148,11 +144,10 @@ func (s *AppFlowTestSuite) testAppFlow(
 			fmt.Sprintf("/apps/%s", app1ID),
 		),
 	)
-	assert.Equal(s.T(), fiber.ErrNotFound.Code, client.GetStatusCode())
+	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 
 	client = s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodDelete,
 		).WithNamespace(
@@ -163,14 +158,13 @@ func (s *AppFlowTestSuite) testAppFlow(
 			fmt.Sprintf("/apps/%s", app1ID),
 		),
 	)
-	assert.Equal(s.T(), fiber.ErrNotFound.Code, client.GetStatusCode())
+	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 }
 
 func (s *AppFlowTestSuite) deleteAppAndCompare(namespaceCode string, appID string) {
 	client := s.AIMClient()
 	appResp := response.App{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodDelete,
 		).WithNamespace(
@@ -181,14 +175,13 @@ func (s *AppFlowTestSuite) deleteAppAndCompare(namespaceCode string, appID strin
 			fmt.Sprintf("/apps/%s", appID),
 		),
 	)
-	assert.Equal(s.T(), fiber.StatusOK, client.GetStatusCode())
+	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
 func (s *AppFlowTestSuite) updateAppAndCompare(namespaceCode string, appID string) {
 	client := s.AIMClient()
 	appResp := response.App{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodPut,
 		).WithNamespace(
@@ -206,15 +199,14 @@ func (s *AppFlowTestSuite) updateAppAndCompare(namespaceCode string, appID strin
 			fmt.Sprintf("/apps/%s", appID),
 		),
 	)
-	assert.Equal(s.T(), appID, appResp.ID)
-	assert.Equal(s.T(), fiber.StatusOK, client.GetStatusCode())
+	s.Equal(appID, appResp.ID)
+	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
 func (s *AppFlowTestSuite) getAppAndCompare(namespaceCode string, appID string) response.App {
 	appResp := response.App{}
 	client := s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodGet,
 		).WithNamespace(
@@ -225,15 +217,14 @@ func (s *AppFlowTestSuite) getAppAndCompare(namespaceCode string, appID string) 
 			fmt.Sprintf("/apps/%s", appID),
 		),
 	)
-	assert.Equal(s.T(), appID, appResp.ID)
-	assert.Equal(s.T(), fiber.StatusOK, client.GetStatusCode())
+	s.Equal(appID, appResp.ID)
+	s.Equal(fiber.StatusOK, client.GetStatusCode())
 	return appResp
 }
 
 func (s *AppFlowTestSuite) getApps(namespaceCode string) []response.App {
 	resp := []response.App{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodGet,
 		).WithNamespace(
@@ -249,8 +240,7 @@ func (s *AppFlowTestSuite) getApps(namespaceCode string) []response.App {
 
 func (s *AppFlowTestSuite) createAppAndCompare(namespace string, req *request.CreateApp) string {
 	var resp response.App
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -263,8 +253,8 @@ func (s *AppFlowTestSuite) createAppAndCompare(namespace string, req *request.Cr
 			"/apps",
 		),
 	)
-	assert.Equal(s.T(), req.Type, resp.Type)
-	assert.Equal(s.T(), req.State["app-state-key"], resp.State["app-state-key"])
-	assert.NotEmpty(s.T(), resp.ID)
+	s.Equal(req.Type, resp.Type)
+	s.Equal(req.State["app-state-key"], resp.State["app-state-key"])
+	s.NotEmpty(resp.ID)
 	return resp.ID
 }

--- a/tests/integration/golang/aim/namespace/flows/dashboard_test.go
+++ b/tests/integration/golang/aim/namespace/flows/dashboard_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -30,7 +28,7 @@ func TestDashboardFlowTestSuite(t *testing.T) {
 }
 
 func (s *DashboardFlowTestSuite) TearDownTest() {
-	assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *DashboardFlowTestSuite) Test_Ok() {
@@ -59,7 +57,7 @@ func (s *DashboardFlowTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			defer func() {
-				assert.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Nil(s.NamespaceFixtures.UnloadFixtures())
 			}()
 
 			// setup namespaces
@@ -68,7 +66,7 @@ func (s *DashboardFlowTestSuite) Test_Ok() {
 					Code:                nsCode,
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 			}
 
 			// run actual flow test over the test data.
@@ -111,14 +109,14 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 	// test `GET /dashboards` endpoint with namespace 1
 	resp := s.getDashboards(namespace1Code)
 	// only dashboard 1 should be present
-	assert.Equal(s.T(), 1, len(resp))
-	assert.Equal(s.T(), dashboard1ID, resp[0].ID)
+	s.Equal(1, len(resp))
+	s.Equal(dashboard1ID, resp[0].ID)
 
 	// test `GET /dashboards` endpoint with namespace 2
 	resp = s.getDashboards(namespace2Code)
 	// only dashboard 2 should be present
-	assert.Equal(s.T(), 1, len(resp))
-	assert.Equal(s.T(), dashboard2ID, resp[0].ID)
+	s.Equal(1, len(resp))
+	s.Equal(dashboard2ID, resp[0].ID)
 
 	// IDs from active namespace can be fetched, updated, and deleted
 	s.getDashboardAndCompare(namespace1Code, dashboard1ID)
@@ -128,8 +126,7 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 	// IDs from other namespace cannot be fetched, updated, or deleted
 	errResp := response.Error{}
 	client := s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodGet,
 		).WithNamespace(
@@ -140,11 +137,10 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 			fmt.Sprintf("/dashboards/%s", dashboard2ID),
 		),
 	)
-	assert.Equal(s.T(), fiber.ErrNotFound.Code, client.GetStatusCode())
+	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 
 	client = s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodPut,
 		).WithNamespace(
@@ -160,11 +156,10 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 			fmt.Sprintf("/dashboards/%s", dashboard1ID),
 		),
 	)
-	assert.Equal(s.T(), fiber.ErrNotFound.Code, client.GetStatusCode())
+	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 
 	client = s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodDelete,
 		).WithNamespace(
@@ -175,14 +170,13 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 			fmt.Sprintf("/dashboards/%s", dashboard1ID),
 		),
 	)
-	assert.Equal(s.T(), fiber.ErrNotFound.Code, client.GetStatusCode())
+	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 }
 
 func (s *DashboardFlowTestSuite) deleteDashboardAndCompare(namespaceCode string, dashboardID string) {
 	client := s.AIMClient()
 	dashboardResp := response.Dashboard{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodDelete,
 		).WithNamespace(
@@ -193,14 +187,13 @@ func (s *DashboardFlowTestSuite) deleteDashboardAndCompare(namespaceCode string,
 			"/dashboards/%s", dashboardID,
 		),
 	)
-	assert.Equal(s.T(), fiber.StatusOK, client.GetStatusCode())
+	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
 func (s *DashboardFlowTestSuite) updateDashboardAndCompare(namespaceCode string, dashboardID string) {
 	client := s.AIMClient()
 	dashboardResp := response.Dashboard{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodPut,
 		).WithNamespace(
@@ -216,15 +209,14 @@ func (s *DashboardFlowTestSuite) updateDashboardAndCompare(namespaceCode string,
 			fmt.Sprintf("/dashboards/%s", dashboardID),
 		),
 	)
-	assert.Equal(s.T(), dashboardID, dashboardResp.ID)
-	assert.Equal(s.T(), fiber.StatusOK, client.GetStatusCode())
+	s.Equal(dashboardID, dashboardResp.ID)
+	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
 func (s *DashboardFlowTestSuite) getDashboardAndCompare(namespaceCode string, dashboardID string) response.Dashboard {
 	dashboardResp := response.Dashboard{}
 	client := s.AIMClient()
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.WithMethod(
 			http.MethodGet,
 		).WithNamespace(
@@ -235,15 +227,14 @@ func (s *DashboardFlowTestSuite) getDashboardAndCompare(namespaceCode string, da
 			fmt.Sprintf("/dashboards/%s", dashboardID),
 		),
 	)
-	assert.Equal(s.T(), dashboardID, dashboardResp.ID)
-	assert.Equal(s.T(), fiber.StatusOK, client.GetStatusCode())
+	s.Equal(dashboardID, dashboardResp.ID)
+	s.Equal(fiber.StatusOK, client.GetStatusCode())
 	return dashboardResp
 }
 
 func (s *DashboardFlowTestSuite) getDashboards(namespaceCode string) []response.Dashboard {
 	resp := []response.Dashboard{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodGet,
 		).WithNamespace(
@@ -259,8 +250,7 @@ func (s *DashboardFlowTestSuite) getDashboards(namespaceCode string) []response.
 
 func (s *DashboardFlowTestSuite) createApp(namespace string, req *request.CreateApp) string {
 	var resp response.App
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -278,8 +268,7 @@ func (s *DashboardFlowTestSuite) createApp(namespace string, req *request.Create
 
 func (s *DashboardFlowTestSuite) createDashboard(namespace string, req *request.CreateDashboard) string {
 	var resp response.Dashboard
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -292,7 +281,7 @@ func (s *DashboardFlowTestSuite) createDashboard(namespace string, req *request.
 			"/dashboards",
 		),
 	)
-	assert.Equal(s.T(), req.Name, resp.Name)
-	assert.NotEmpty(s.T(), resp.ID)
+	s.Equal(req.Name, resp.Name)
+	s.NotEmpty(resp.ID)
 	return resp.ID
 }

--- a/tests/integration/golang/aim/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/aim/namespace/flows/experiment_test.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -33,7 +31,7 @@ func TestExperimentFlowTestSuite(t *testing.T) {
 }
 
 func (s *ExperimentFlowTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *ExperimentFlowTestSuite) Test_Ok() {
@@ -89,14 +87,14 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			namespace2, err = s.NamespaceFixtures.CreateNamespace(context.Background(), namespace2)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment1",
@@ -104,7 +102,7 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:             "id1",
@@ -116,7 +114,7 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri1",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment2",
@@ -124,7 +122,7 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:             "id2",
@@ -136,7 +134,7 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri2",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. run actual flow test over the test data.
 			s.testRunFlow(tt.namespace1Code, tt.namespace2Code, experiment1, experiment2, run1, run2)
@@ -218,8 +216,7 @@ func (s *ExperimentFlowTestSuite) getExperimentAndCompare(
 	namespace string, experimentID int32, expectedResponse *response.GetExperiment,
 ) {
 	var resp response.GetExperiment
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace,
 		).WithResponse(
@@ -228,19 +225,19 @@ func (s *ExperimentFlowTestSuite) getExperimentAndCompare(
 			"/experiments/%d", experimentID,
 		),
 	)
-	assert.Equal(s.T(), expectedResponse.ID, resp.ID)
-	assert.Equal(s.T(), expectedResponse.Name, resp.Name)
-	assert.Equal(s.T(), expectedResponse.Description, resp.Description)
-	assert.Equal(s.T(), expectedResponse.Archived, resp.Archived)
-	assert.Equal(s.T(), expectedResponse.RunCount, resp.RunCount)
+	s.Equal(expectedResponse.ID, resp.ID)
+	s.Equal(expectedResponse.Name, resp.Name)
+	s.Equal(expectedResponse.Description, resp.Description)
+	s.Equal(expectedResponse.Archived, resp.Archived)
+	s.Equal(expectedResponse.RunCount, resp.RunCount)
 }
 
 func (s *ExperimentFlowTestSuite) getExperimentsAndCompare(
 	namespace string, expectedResponse response.Experiments,
 ) {
 	var resp response.Experiments
-	require.Nil(
-		s.T(), s.AIMClient().WithNamespace(
+	s.Require().Nil(
+		s.AIMClient().WithNamespace(
 			namespace,
 		).WithResponse(
 			&resp,
@@ -248,15 +245,14 @@ func (s *ExperimentFlowTestSuite) getExperimentsAndCompare(
 			"/experiments",
 		),
 	)
-	assert.ElementsMatch(s.T(), expectedResponse, resp)
+	s.ElementsMatch(expectedResponse, resp)
 }
 
 func (s *ExperimentFlowTestSuite) getExperimentRunsAndCompare(
 	namespace string, experimentID int32, expectedResponse response.GetExperimentRuns,
 ) {
 	var resp response.GetExperimentRuns
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace,
 		).WithResponse(
@@ -265,16 +261,15 @@ func (s *ExperimentFlowTestSuite) getExperimentRunsAndCompare(
 			"/experiments/%d/runs", experimentID,
 		),
 	)
-	assert.Equal(s.T(), expectedResponse.ID, resp.ID)
-	assert.ElementsMatch(s.T(), expectedResponse.Runs, resp.Runs)
+	s.Equal(expectedResponse.ID, resp.ID)
+	s.ElementsMatch(expectedResponse.Runs, resp.Runs)
 }
 
 func (s *ExperimentFlowTestSuite) getExperimentActivityAndCompare(
 	namespace string, experimentID int32, expectedResponse *response.GetExperimentActivity,
 ) {
 	var resp response.GetExperimentActivity
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithResponse(
 			&resp,
 		).WithNamespace(
@@ -283,15 +278,14 @@ func (s *ExperimentFlowTestSuite) getExperimentActivityAndCompare(
 			"/experiments/%d/activity", experimentID,
 		),
 	)
-	assert.Equal(s.T(), expectedResponse.NumRuns, resp.NumRuns)
-	assert.Equal(s.T(), expectedResponse.NumArchivedRuns, expectedResponse.NumArchivedRuns)
-	assert.Equal(s.T(), expectedResponse.NumActiveRuns, expectedResponse.NumActiveRuns)
+	s.Equal(expectedResponse.NumRuns, resp.NumRuns)
+	s.Equal(expectedResponse.NumArchivedRuns, expectedResponse.NumArchivedRuns)
+	s.Equal(expectedResponse.NumActiveRuns, expectedResponse.NumActiveRuns)
 }
 
 func (s *ExperimentFlowTestSuite) deleteExperiment(namespace string, experimentID int32) {
 	var resp response.DeleteExperiment
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodDelete,
 		).WithNamespace(
@@ -302,6 +296,6 @@ func (s *ExperimentFlowTestSuite) deleteExperiment(namespace string, experimentI
 			"/experiments/%d", experimentID,
 		),
 	)
-	assert.Equal(s.T(), "OK", resp.Status)
-	assert.Equal(s.T(), fmt.Sprintf("%d", experimentID), resp.ID)
+	s.Equal("OK", resp.Status)
+	s.Equal(fmt.Sprintf("%d", experimentID), resp.ID)
 }

--- a/tests/integration/golang/aim/namespace/flows/metric_test.go
+++ b/tests/integration/golang/aim/namespace/flows/metric_test.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -34,7 +32,7 @@ func TestMetricTestSuite(t *testing.T) {
 }
 
 func (s *MetricFlowTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *MetricFlowTestSuite) Test_Ok() {
@@ -90,14 +88,14 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			namespace2, err = s.NamespaceFixtures.CreateNamespace(context.Background(), namespace2)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment1",
@@ -105,7 +103,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// create different test runs and attach tags, metrics, params, etc.
 			run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -126,7 +124,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri1",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 				Key:       "TestMetric1",
 				Value:     1.1,
@@ -136,7 +134,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				RunID:     run1.ID,
 				Iter:      1,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			metric1Run1, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 				Key:       "TestMetric1",
 				Value:     1.1,
@@ -146,19 +144,19 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				RunID:     run1.ID,
 				LastIter:  1,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 				Key:   "param1",
 				Value: "value1",
 				RunID: run1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 				Key:   "mlflow.runName",
 				Value: "TestRunTag1",
 				RunID: run1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment2",
@@ -166,7 +164,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:         "id2",
@@ -186,7 +184,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri2",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 				Key:       "TestMetric2",
 				Value:     0.5,
@@ -196,7 +194,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				RunID:     run2.ID,
 				Iter:      3,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			metric1Run2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 				Key:       "TestMetric2",
 				Value:     0.5,
@@ -206,19 +204,19 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				RunID:     run2.ID,
 				LastIter:  3,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 				Key:   "param2",
 				Value: "value2",
 				RunID: run2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 				Key:   "mlflow.runName",
 				Value: "TestRunTag2",
 				RunID: run2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. run actual flow test over the test data.
 			s.testRunFlow(
@@ -281,8 +279,7 @@ func (s *MetricFlowTestSuite) searchMetricsAndCompare(
 	expectedMetrics []*models.LatestMetric,
 ) {
 	resp := new(bytes.Buffer)
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace,
 		).WithQuery(
@@ -294,7 +291,7 @@ func (s *MetricFlowTestSuite) searchMetricsAndCompare(
 		).DoRequest("/runs/search/metric"),
 	)
 	decodedData, err := encoding.Decode(resp)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var decodedMetrics []*models.LatestMetric
 	for _, run := range expectedRuns {
@@ -322,14 +319,14 @@ func (s *MetricFlowTestSuite) searchMetricsAndCompare(
 	}
 
 	// Check if the received metrics match the expected ones
-	assert.Equal(s.T(), expectedMetrics, decodedMetrics)
+	s.Equal(expectedMetrics, decodedMetrics)
 }
 
 func (s *MetricFlowTestSuite) searchAlignedMetricsAndCompare(
 	namespace string, request *request.GetAlignedMetricRequest, expectedRuns []*models.Run, expectedResponse []float64,
 ) {
 	resp := new(bytes.Buffer)
-	require.Nil(s.T(), s.AIMClient().WithMethod(
+	s.Require().Nil(s.AIMClient().WithMethod(
 		http.MethodPost,
 	).WithNamespace(
 		namespace,
@@ -344,7 +341,7 @@ func (s *MetricFlowTestSuite) searchAlignedMetricsAndCompare(
 	))
 
 	decodedData, err := encoding.Decode(resp)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	xValues := make(map[int][]float64)
 
@@ -360,6 +357,6 @@ func (s *MetricFlowTestSuite) searchAlignedMetricsAndCompare(
 
 	// Check if the received values for each metric match the expected ones
 	for _, metricValues := range xValues {
-		assert.Equal(s.T(), expectedResponse, metricValues)
+		s.Equal(expectedResponse, metricValues)
 	}
 }

--- a/tests/integration/golang/aim/namespace/flows/project_test.go
+++ b/tests/integration/golang/aim/namespace/flows/project_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -31,7 +29,7 @@ func TestProjectFlowTestSuite(t *testing.T) {
 }
 
 func (s *ProjectFlowTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *ProjectFlowTestSuite) Test_Ok() {
@@ -87,14 +85,14 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			namespace2, err = s.NamespaceFixtures.CreateNamespace(context.Background(), namespace2)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment1",
@@ -102,7 +100,7 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:             "id1",
@@ -114,9 +112,9 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri1",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
-			require.Nil(
-				s.T(), s.RunFixtures.CreateMetric(
+			s.Require().Nil(err)
+			s.Require().Nil(
+				s.RunFixtures.CreateMetric(
 					context.Background(),
 					&models.Metric{
 						Key:       "key1",
@@ -139,21 +137,21 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 				RunID:     run1.ID,
 				LastIter:  1,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			tag1, err := s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 				Key:   "tag1",
 				Value: "value1",
 				RunID: run1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			param1, err := s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 				Key:   "param1",
 				Value: "value1",
 				RunID: run1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment2",
@@ -161,7 +159,7 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:             "id2",
@@ -173,7 +171,7 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri2",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			metric2, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 				Key:       "metric2",
@@ -184,21 +182,21 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 				RunID:     run2.ID,
 				LastIter:  1,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			tag2, err := s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 				Key:   "tag2",
 				Value: "value2",
 				RunID: run2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			param2, err := s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 				Key:   "param2",
 				Value: "value2",
 				RunID: run2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. run actual flow test over the test data.
 			s.testRunFlow(
@@ -251,28 +249,27 @@ func (s *ProjectFlowTestSuite) getProjectAndCompare(
 	namespace string, expectedResponse *response.GetProjectResponse,
 ) {
 	var resp response.GetProjectResponse
-	require.Nil(
-		s.T(), s.AIMClient().WithNamespace(namespace).WithResponse(&resp).DoRequest("/projects"),
+	s.Require().Nil(
+		s.AIMClient().WithNamespace(namespace).WithResponse(&resp).DoRequest("/projects"),
 	)
-	assert.Equal(s.T(), expectedResponse.Name, resp.Name)
-	assert.Equal(s.T(), expectedResponse.Description, resp.Description)
-	assert.Equal(s.T(), expectedResponse.TelemetryEnabled, resp.TelemetryEnabled)
+	s.Equal(expectedResponse.Name, resp.Name)
+	s.Equal(expectedResponse.Description, resp.Description)
+	s.Equal(expectedResponse.TelemetryEnabled, resp.TelemetryEnabled)
 }
 
 func (s *ProjectFlowTestSuite) getProjectStatusAndCompare(namespace string) {
 	var resp string
-	require.Nil(
-		s.T(), s.AIMClient().WithNamespace(namespace).WithResponse(&resp).DoRequest("/projects/status"),
+	s.Require().Nil(
+		s.AIMClient().WithNamespace(namespace).WithResponse(&resp).DoRequest("/projects/status"),
 	)
-	assert.Equal(s.T(), "up-to-date", resp)
+	s.Equal("up-to-date", resp)
 }
 
 func (s *ProjectFlowTestSuite) getProjectParamsAndCompare(
 	namespace string, metric *models.LatestMetric, param *models.Param, tag *models.Tag,
 ) {
 	resp := response.ProjectParamsResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace,
 		).WithQuery(
@@ -282,10 +279,10 @@ func (s *ProjectFlowTestSuite) getProjectParamsAndCompare(
 		).DoRequest("/projects/params"),
 	)
 
-	assert.Equal(s.T(), 1, len(resp.Metric))
+	s.Equal(1, len(resp.Metric))
 	_, ok := resp.Metric[metric.Key]
-	assert.True(s.T(), ok)
-	assert.Equal(s.T(), map[string]interface{}{
+	s.True(ok)
+	s.Equal(map[string]interface{}{
 		param.Key: map[string]interface{}{
 			"__example_type__": "<class 'str'>",
 		},
@@ -301,12 +298,12 @@ func (s *ProjectFlowTestSuite) getProjectActivityAndCompare(
 	namespace string, expectedResponse *response.ProjectActivityResponse,
 ) {
 	var resp response.ProjectActivityResponse
-	require.Nil(
-		s.T(), s.AIMClient().WithNamespace(namespace).WithResponse(&resp).DoRequest("/projects/activity"),
+	s.Require().Nil(
+		s.AIMClient().WithNamespace(namespace).WithResponse(&resp).DoRequest("/projects/activity"),
 	)
 
-	assert.Equal(s.T(), expectedResponse.NumActiveRuns, resp.NumActiveRuns)
-	assert.Equal(s.T(), expectedResponse.NumArchivedRuns, resp.NumArchivedRuns)
-	assert.Equal(s.T(), expectedResponse.NumExperiments, resp.NumExperiments)
-	assert.Equal(s.T(), expectedResponse.NumRuns, resp.NumRuns)
+	s.Equal(expectedResponse.NumActiveRuns, resp.NumActiveRuns)
+	s.Equal(expectedResponse.NumArchivedRuns, resp.NumArchivedRuns)
+	s.Equal(expectedResponse.NumExperiments, resp.NumExperiments)
+	s.Equal(expectedResponse.NumRuns, resp.NumRuns)
 }

--- a/tests/integration/golang/aim/namespace/flows/run_test.go
+++ b/tests/integration/golang/aim/namespace/flows/run_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -41,7 +39,7 @@ func TestRunFlowTestSuite(t *testing.T) {
 }
 
 func (s *RunFlowTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *RunFlowTestSuite) Test_Ok() {
@@ -97,14 +95,14 @@ func (s *RunFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			namespace2, err = s.NamespaceFixtures.CreateNamespace(context.Background(), namespace2)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment1",
@@ -112,7 +110,7 @@ func (s *RunFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:             "id1",
@@ -124,9 +122,9 @@ func (s *RunFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri1",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
-			require.Nil(
-				s.T(), s.RunFixtures.CreateMetric(
+			s.Require().Nil(err)
+			s.Require().Nil(
+				s.RunFixtures.CreateMetric(
 					context.Background(),
 					&models.Metric{
 						Key:       "key1",
@@ -146,7 +144,7 @@ func (s *RunFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 				ID:             "id2",
@@ -158,9 +156,9 @@ func (s *RunFlowTestSuite) Test_Ok() {
 				ArtifactURI:    "artifact_uri2",
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
-			require.Nil(
-				s.T(), s.RunFixtures.CreateMetric(
+			s.Require().Nil(err)
+			s.Require().Nil(
+				s.RunFixtures.CreateMetric(
 					context.Background(),
 					&models.Metric{
 						Key:       "key2",
@@ -323,8 +321,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 	// check that run has been actually deleted.
 	s.deleteRun(namespace1Code, run1.ID)
 	var resp response.Error
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace1Code,
 		).WithResponse(
@@ -333,11 +330,10 @@ func (s *RunFlowTestSuite) testRunFlow(
 			"/runs/%s/info", run1.ID,
 		),
 	)
-	assert.Equal(s.T(), "Not Found", resp.Message)
+	s.Equal("Not Found", resp.Message)
 
 	s.deleteRun(namespace2Code, run2.ID)
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace2Code,
 		).WithResponse(
@@ -346,7 +342,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 			"/runs/%s/info", run1.ID,
 		),
 	)
-	assert.Equal(s.T(), "Not Found", resp.Message)
+	s.Equal("Not Found", resp.Message)
 
 	// test `DELETE /runs/delete-batch` endpoint.
 	// recreate deleted runs.
@@ -363,7 +359,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.getRunAndCompare(namespace1Code, run3.ID, &response.GetRunInfo{
 		Props: response.GetRunInfoProps{
 			Name:     "TestRun3",
@@ -371,8 +367,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 		},
 	})
 	s.deleteRunBatch(namespace1Code, []string{run3.ID})
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace1Code,
 		).WithResponse(
@@ -381,7 +376,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 			"/runs/%s/info", run3.ID,
 		),
 	)
-	assert.Equal(s.T(), "Not Found", resp.Message)
+	s.Equal("Not Found", resp.Message)
 
 	run4, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "id4",
@@ -393,7 +388,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 		ArtifactURI:    "artifact_uri4",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.getRunAndCompare(namespace2Code, run4.ID, &response.GetRunInfo{
 		Props: response.GetRunInfoProps{
 			Name:     "TestRun4",
@@ -401,8 +396,7 @@ func (s *RunFlowTestSuite) testRunFlow(
 		},
 	})
 	s.deleteRunBatch(namespace2Code, []string{run4.ID})
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace2Code,
 		).WithResponse(
@@ -411,12 +405,11 @@ func (s *RunFlowTestSuite) testRunFlow(
 			"/runs/%s/info", run4.ID,
 		),
 	)
-	assert.Equal(s.T(), "Not Found", resp.Message)
+	s.Equal("Not Found", resp.Message)
 }
 
 func (s *RunFlowTestSuite) updateRun(namespace string, req *request.UpdateRunRequest) {
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPut,
 		).WithNamespace(
@@ -433,24 +426,22 @@ func (s *RunFlowTestSuite) getRunAndCompare(
 	namespace string, runID string, expectedResponse *response.GetRunInfo,
 ) {
 	var resp response.GetRunInfo
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithNamespace(
 			namespace,
 		).WithResponse(
 			&resp,
 		).DoRequest("/runs/%s/info", runID),
 	)
-	assert.Equal(s.T(), expectedResponse.Props.Name, resp.Props.Name)
-	assert.Equal(s.T(), expectedResponse.Props.Archived, resp.Props.Archived)
+	s.Equal(expectedResponse.Props.Name, resp.Props.Name)
+	s.Equal(expectedResponse.Props.Archived, resp.Props.Archived)
 }
 
 func (s *RunFlowTestSuite) searchRunsAndCompare(
 	namespace string, request request.SearchRunsRequest, expectedRunList []models.Run,
 ) {
 	resp := new(bytes.Buffer)
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithResponseType(
 			helpers.ResponseTypeBuffer,
 		).WithQuery(
@@ -463,25 +454,21 @@ func (s *RunFlowTestSuite) searchRunsAndCompare(
 	)
 
 	decodedData, err := encoding.Decode(resp)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	for _, expectedRun := range expectedRunList {
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			expectedRun.Name,
 			decodedData[fmt.Sprintf("%v.props.name", expectedRun.ID)],
 		)
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			fmt.Sprintf("%d", expectedRun.ExperimentID),
 			decodedData[fmt.Sprintf("%v.props.experiment.id", expectedRun.ID)],
 		)
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			expectedRun.Status == models.StatusRunning,
 			decodedData[fmt.Sprintf("%v.props.active", expectedRun.ID)],
 		)
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			expectedRun.LifecycleStage == models.LifecycleStageDeleted,
 			decodedData[fmt.Sprintf("%v.props.archived", expectedRun.ID)],
 		)
@@ -490,8 +477,7 @@ func (s *RunFlowTestSuite) searchRunsAndCompare(
 
 func (s *RunFlowTestSuite) getActiveRunsAndCompare(namespace string, expectedRunList []models.Run) {
 	resp := new(bytes.Buffer)
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithResponseType(
 			helpers.ResponseTypeBuffer,
 		).WithNamespace(
@@ -502,25 +488,21 @@ func (s *RunFlowTestSuite) getActiveRunsAndCompare(namespace string, expectedRun
 	)
 
 	decodedData, err := encoding.Decode(resp)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	for _, expectedRun := range expectedRunList {
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			expectedRun.Name,
 			decodedData[fmt.Sprintf("%v.props.name", expectedRun.ID)],
 		)
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			fmt.Sprintf("%d", expectedRun.ExperimentID),
 			decodedData[fmt.Sprintf("%v.props.experiment.id", expectedRun.ID)],
 		)
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			expectedRun.Status == models.StatusRunning,
 			decodedData[fmt.Sprintf("%v.props.active", expectedRun.ID)],
 		)
-		assert.Equal(
-			s.T(),
+		s.Equal(
 			expectedRun.LifecycleStage == models.LifecycleStageDeleted,
 			decodedData[fmt.Sprintf("%v.props.archived", expectedRun.ID)],
 		)
@@ -531,8 +513,7 @@ func (s *RunFlowTestSuite) getRunMetricsAndCompare(
 	namespace, runID string, request *request.GetRunMetrics, expectedMetrics response.GetRunMetrics,
 ) {
 	var resp response.GetRunMetrics
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -545,13 +526,12 @@ func (s *RunFlowTestSuite) getRunMetricsAndCompare(
 			"/runs/%s/metric/get-batch", runID,
 		),
 	)
-	assert.ElementsMatch(s.T(), expectedMetrics, resp)
+	s.ElementsMatch(expectedMetrics, resp)
 }
 
 func (s *RunFlowTestSuite) archiveRunsBatch(namespace string, runIDs []string, archive bool) {
 	resp := map[string]any{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -566,13 +546,12 @@ func (s *RunFlowTestSuite) archiveRunsBatch(namespace string, runIDs []string, a
 			"/runs/archive-batch",
 		),
 	)
-	assert.Equal(s.T(), map[string]interface{}{"status": "OK"}, resp)
+	s.Equal(map[string]interface{}{"status": "OK"}, resp)
 }
 
 func (s *RunFlowTestSuite) deleteRun(namespace, runID string) {
 	var resp fiber.Map
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodDelete,
 		).WithNamespace(
@@ -583,13 +562,12 @@ func (s *RunFlowTestSuite) deleteRun(namespace, runID string) {
 			"/runs/%s", runID,
 		),
 	)
-	assert.Equal(s.T(), fiber.Map{"id": runID, "status": "OK"}, resp)
+	s.Equal(fiber.Map{"id": runID, "status": "OK"}, resp)
 }
 
 func (s *RunFlowTestSuite) deleteRunBatch(namespace string, runIDs []string) {
 	resp := fiber.Map{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -602,5 +580,5 @@ func (s *RunFlowTestSuite) deleteRunBatch(namespace string, runIDs []string) {
 			"/runs/delete-batch",
 		),
 	)
-	assert.Equal(s.T(), fiber.Map{"status": "OK"}, resp)
+	s.Equal(fiber.Map{"status": "OK"}, resp)
 }

--- a/tests/integration/golang/aim/namespace/namespace_test.go
+++ b/tests/integration/golang/aim/namespace/namespace_test.go
@@ -5,8 +5,6 @@ package namespace
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
@@ -22,7 +20,7 @@ func TestNamespaceTestSuite(t *testing.T) {
 }
 
 func (s *NamespaceTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *NamespaceTestSuite) Test_Error() {
@@ -49,8 +47,7 @@ func (s *NamespaceTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithNamespace(
 					tt.namespace,
 				).WithResponse(
@@ -59,8 +56,8 @@ func (s *NamespaceTestSuite) Test_Error() {
 					"/experiments",
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
-			assert.Equal(s.T(), api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
+			s.Equal(tt.error.Error(), resp.Error())
+			s.Equal(api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
 		})
 	}
 }

--- a/tests/integration/golang/aim/project/get_project_activity_test.go
+++ b/tests/integration/golang/aim/project/get_project_activity_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -27,7 +25,7 @@ func TestGetProjectActivityTestSuite(t *testing.T) {
 
 func (s *GetProjectActivityTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -35,31 +33,31 @@ func (s *GetProjectActivityTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	archivedRunsIds := []string{runs[0].ID, runs[1].ID}
 	err = s.RunFixtures.ArchiveRuns(context.Background(), namespace.ID, archivedRunsIds)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp response.ProjectActivityResponse
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/projects/activity"))
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/projects/activity"))
 
-	assert.Equal(s.T(), 8, resp.NumActiveRuns)
-	assert.Equal(s.T(), 2, resp.NumArchivedRuns)
-	assert.Equal(s.T(), 1, resp.NumExperiments)
-	assert.Equal(s.T(), 10, resp.NumRuns)
-	assert.Equal(s.T(), 1, len(resp.ActivityMap))
+	s.Equal(8, resp.NumActiveRuns)
+	s.Equal(2, resp.NumArchivedRuns)
+	s.Equal(1, resp.NumExperiments)
+	s.Equal(10, resp.NumRuns)
+	s.Equal(1, len(resp.ActivityMap))
 	for _, v := range resp.ActivityMap {
-		assert.Equal(s.T(), 10, v)
+		s.Equal(10, v)
 	}
 }

--- a/tests/integration/golang/aim/project/get_project_params_test.go
+++ b/tests/integration/golang/aim/project/get_project_params_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -27,7 +25,7 @@ func TestGetProjectParamsTestSuite(t *testing.T) {
 
 func (s *GetProjectParamsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// 1. create test `namespace` and connect test `run`.
@@ -36,7 +34,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// 2. create test `experiment` and connect test `run`.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -44,7 +42,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "id",
@@ -54,7 +52,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// 3. create latest metric.
 	metric, err := s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
@@ -66,7 +64,7 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		RunID:     run.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// 4. create test param and tag.
 	tag, err := s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -74,19 +72,18 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	param, err := s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// 5. check that response contains metric from previous step.
 	resp := response.ProjectParamsResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithQuery(
 			map[any]any{"sequence": "metric"},
 		).WithResponse(
@@ -94,10 +91,10 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 		).DoRequest("/projects/params"),
 	)
 
-	assert.Equal(s.T(), 1, len(resp.Metric))
+	s.Equal(1, len(resp.Metric))
 	_, ok := resp.Metric[metric.Key]
-	assert.True(s.T(), ok)
-	assert.Equal(s.T(), map[string]interface{}{
+	s.True(ok)
+	s.Equal(map[string]interface{}{
 		param.Key: map[string]interface{}{
 			"__example_type__": "<class 'str'>",
 		},
@@ -110,26 +107,25 @@ func (s *GetProjectParamsTestSuite) Test_Ok() {
 
 	// 6. mark run as `deleted`.
 	run.LifecycleStage = models.LifecycleStageDeleted
-	require.Nil(s.T(), s.RunFixtures.UpdateRun(context.Background(), run))
+	s.Require().Nil(s.RunFixtures.UpdateRun(context.Background(), run))
 
 	// 7. check that endpoint returns an empty response.
 	resp = response.ProjectParamsResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.AIMClient().WithQuery(
 			map[any]any{"sequence": "metric"},
 		).WithResponse(
 			&resp,
 		).DoRequest("/projects/params"),
 	)
-	assert.Equal(s.T(), 0, len(resp.Metric))
+	s.Equal(0, len(resp.Metric))
 	_, ok = resp.Metric[metric.Key]
-	assert.False(s.T(), ok)
-	assert.Equal(s.T(), map[string]interface{}{"tags": map[string]interface{}{}}, resp.Params)
+	s.False(ok)
+	s.Equal(map[string]interface{}{"tags": map[string]interface{}{}}, resp.Params)
 }
 
 func (s *GetProjectParamsTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 }

--- a/tests/integration/golang/aim/project/get_project_status_test.go
+++ b/tests/integration/golang/aim/project/get_project_status_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -25,7 +23,7 @@ func TestGetProjectStatusTestSuite(t *testing.T) {
 
 func (s *GetProjectStatusTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -33,9 +31,9 @@ func (s *GetProjectStatusTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp string
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/projects/status"))
-	assert.Equal(s.T(), "up-to-date", resp)
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/projects/status"))
+	s.Equal("up-to-date", resp)
 }

--- a/tests/integration/golang/aim/project/get_project_test.go
+++ b/tests/integration/golang/aim/project/get_project_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -26,7 +24,7 @@ func TestGetProjectTestSuite(t *testing.T) {
 
 func (s *GetProjectTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -34,12 +32,12 @@ func (s *GetProjectTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	var resp response.GetProjectResponse
-	require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/projects"))
-	assert.Equal(s.T(), "FastTrackML", resp.Name)
-	// assert.Equal(s.T(), "", resp.Path)
-	assert.Equal(s.T(), "", resp.Description)
-	assert.Equal(s.T(), 0, resp.TelemetryEnabled)
+	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/projects"))
+	s.Equal("FastTrackML", resp.Name)
+	// s.Equal( "", resp.Path)
+	s.Equal("", resp.Description)
+	s.Equal(0, resp.TelemetryEnabled)
 }

--- a/tests/integration/golang/aim/run/archive_batch_test.go
+++ b/tests/integration/golang/aim/run/archive_batch_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -35,22 +33,22 @@ func (s *ArchiveBatchTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 }
 
 func (s *ArchiveBatchTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	tests := []struct {
@@ -83,11 +81,10 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			resp := map[string]any{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(http.MethodPost).WithQuery(map[any]any{
 					"archive": tt.archiveParam,
 				}).WithRequest(
@@ -98,32 +95,32 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 					"/runs/archive-batch",
 				),
 			)
-			assert.Equal(s.T(), map[string]interface{}{"status": "OK"}, resp)
+			s.Equal(map[string]interface{}{"status": "OK"}, resp)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), 10, len(runs))
+			s.Require().Nil(err)
+			s.Equal(10, len(runs))
 			archiveCount := 0
 			for _, run := range runs {
 				if run.LifecycleStage == models.LifecycleStageDeleted {
 					archiveCount++
 				}
 			}
-			assert.Equal(s.T(), tt.expectedArchiveCount, archiveCount)
+			s.Equal(tt.expectedArchiveCount, archiveCount)
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
-			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
+			s.Require().Nil(err)
+			s.Equal(originalMinRowNum, newMinRowNum)
+			s.Equal(originalMaxRowNum, newMaxRowNum)
 		})
 	}
 }
 
 func (s *ArchiveBatchTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -141,11 +138,10 @@ func (s *ArchiveBatchTestSuite) Test_Error() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			var resp fiber.Map
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(http.MethodPost).WithQuery(map[any]any{
 					"archive": true,
 				}).WithRequest(
@@ -156,18 +152,18 @@ func (s *ArchiveBatchTestSuite) Test_Error() {
 					"/runs/archive-batch",
 				),
 			)
-			assert.Equal(s.T(), fiber.Map{"status": "OK"}, resp)
+			s.Equal(fiber.Map{"status": "OK"}, resp)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
-			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
+			s.Require().Nil(err)
+			s.Equal(originalMinRowNum, newMinRowNum)
+			s.Equal(originalMaxRowNum, newMaxRowNum)
 		})
 	}
 }

--- a/tests/integration/golang/aim/run/delete_batch_test.go
+++ b/tests/integration/golang/aim/run/delete_batch_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
@@ -36,22 +34,22 @@ func (s *DeleteBatchTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 }
 
 func (s *DeleteBatchTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -74,11 +72,10 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			resp := fiber.Map{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(http.MethodPost).WithRequest(
 					tt.runIDs,
 				).WithResponse(
@@ -87,25 +84,25 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 					"/runs/delete-batch",
 				),
 			)
-			assert.Equal(s.T(), fiber.Map{"status": "OK"}, resp)
+			s.Equal(fiber.Map{"status": "OK"}, resp)
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
-			assert.Greater(s.T(), originalMaxRowNum, newMaxRowNum)
+			s.Require().Nil(err)
+			s.Equal(originalMinRowNum, newMinRowNum)
+			s.Greater(originalMaxRowNum, newMaxRowNum)
 		})
 	}
 }
 
 func (s *DeleteBatchTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -123,11 +120,10 @@ func (s *DeleteBatchTestSuite) Test_Error() {
 			originalMinRowNum, originalMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			var resp api.ErrorResponse
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(http.MethodPost).WithRequest(
 					tt.request,
 				).WithResponse(
@@ -136,18 +132,18 @@ func (s *DeleteBatchTestSuite) Test_Error() {
 					"/runs/delete-batch",
 				),
 			)
-			assert.Contains(s.T(), resp.Error(), "count of deleted runs does not match length of ids input")
+			s.Contains(resp.Error(), "count of deleted runs does not match length of ids input")
 
 			runs, err := s.RunFixtures.GetRuns(context.Background(), s.runs[0].ExperimentID)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.expectedRunCount, len(runs))
+			s.Require().Nil(err)
+			s.Equal(tt.expectedRunCount, len(runs))
 
 			newMinRowNum, newMaxRowNum, err := s.RunFixtures.FindMinMaxRowNums(
 				context.Background(), s.runs[0].ExperimentID,
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), originalMinRowNum, newMinRowNum)
-			assert.Equal(s.T(), originalMaxRowNum, newMaxRowNum)
+			s.Require().Nil(err)
+			s.Equal(originalMinRowNum, newMinRowNum)
+			s.Equal(originalMaxRowNum, newMaxRowNum)
 		})
 	}
 }

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
@@ -35,22 +33,22 @@ func (s *GetRunInfoTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 }
 
 func (s *GetRunInfoTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name  string
@@ -64,23 +62,22 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.GetRunInfo
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID),
 			)
-			assert.Equal(s.T(), s.run.Name, resp.Props.Name)
-			assert.Equal(s.T(), fmt.Sprintf("%v", s.run.ExperimentID), resp.Props.Experiment.ID)
-			assert.Equal(s.T(), float64(s.run.StartTime.Int64)/1000, resp.Props.CreationTime)
-			assert.Equal(s.T(), float64(s.run.EndTime.Int64)/1000, resp.Props.EndTime)
+			s.Equal(s.run.Name, resp.Props.Name)
+			s.Equal(fmt.Sprintf("%v", s.run.ExperimentID), resp.Props.Experiment.ID)
+			s.Equal(float64(s.run.StartTime.Int64)/1000, resp.Props.CreationTime)
+			s.Equal(float64(s.run.EndTime.Int64)/1000, resp.Props.EndTime)
 			// TODO this assertion fails because tags are not rendered by endpoint
-			// assert.Equal(s.T(), s.run.Tags[0].Key, resp.Props.Tags[0])
+			// s.Equal( s.run.Tags[0].Key, resp.Props.Tags[0])
 		})
 	}
 }
 
 func (s *GetRunInfoTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name  string
@@ -94,8 +91,8 @@ func (s *GetRunInfoTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(s.T(), s.AIMClient().WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID))
-			assert.Equal(s.T(), "Not Found", resp.Message)
+			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/runs/%s/info", tt.runID))
+			s.Equal("Not Found", resp.Message)
 		})
 	}
 }

--- a/tests/integration/golang/aim/run/get_run_metrics_test.go
+++ b/tests/integration/golang/aim/run/get_run_metrics_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -36,22 +34,22 @@ func (s *GetRunMetricsTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 }
 
 func (s *GetRunMetricsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name             string
@@ -91,8 +89,7 @@ func (s *GetRunMetricsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.GetRunMetrics
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -103,14 +100,14 @@ func (s *GetRunMetricsTestSuite) Test_Ok() {
 					"/runs/%s/metric/get-batch", tt.runID,
 				),
 			)
-			assert.ElementsMatch(s.T(), tt.expectedResponse, resp)
+			s.ElementsMatch(tt.expectedResponse, resp)
 		})
 	}
 }
 
 func (s *GetRunMetricsTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name  string
@@ -126,11 +123,10 @@ func (s *GetRunMetricsTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithResponse(&resp).DoRequest("/runs/%s/metric/get-batch", tt.runID),
 			)
-			assert.Equal(s.T(), tt.error, resp.Message)
+			s.Equal(tt.error, resp.Message)
 		})
 	}
 }

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -30,7 +28,7 @@ func TestGetRunsActiveTestSuite(t *testing.T) {
 
 func (s *GetRunsActiveTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,7 +36,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name         string
@@ -58,10 +56,10 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 					NamespaceID:    namespace.ID,
 					LifecycleStage: models.LifecycleStageActive,
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 
 				s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 3)
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 			},
 		},
 		{
@@ -70,7 +68,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 			beforeRunFn: func() {
 				// set 3rd run to status = StatusFinished
 				s.runs[2].Status = models.StatusFinished
-				require.Nil(s.T(), s.RunFixtures.UpdateRun(context.Background(), s.runs[2]))
+				s.Require().Nil(s.RunFixtures.UpdateRun(context.Background(), s.runs[2]))
 			},
 		},
 	}
@@ -80,8 +78,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 				tt.beforeRunFn()
 			}
 			resp := new(bytes.Buffer)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithResponseType(
 					helpers.ResponseTypeBuffer,
 				).WithResponse(
@@ -89,7 +86,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 				).DoRequest("/runs/active"),
 			)
 			decodedData, err := encoding.Decode(resp)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			responseCount := 0
 			for _, run := range s.runs {
@@ -101,23 +98,23 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 				archivedKey := fmt.Sprintf("%v.props.archived", run.ID)
 				if run.Status == models.StatusRunning && run.LifecycleStage ==
 					models.LifecycleStageActive {
-					assert.Equal(s.T(), run.Name, decodedData[respNameKey])
-					assert.Equal(s.T(), fmt.Sprintf("%v", run.ExperimentID), decodedData[expIdKey])
-					assert.Equal(s.T(), run.Status == models.StatusRunning, decodedData[activeKey])
-					assert.Equal(s.T(), false, decodedData[archivedKey])
-					assert.Equal(s.T(), float64(run.StartTime.Int64)/1000, decodedData[startTimeKey])
-					assert.Equal(s.T(), float64(run.EndTime.Int64)/1000, decodedData[endTimeKey])
+					s.Equal(run.Name, decodedData[respNameKey])
+					s.Equal(fmt.Sprintf("%v", run.ExperimentID), decodedData[expIdKey])
+					s.Equal(run.Status == models.StatusRunning, decodedData[activeKey])
+					s.Equal(false, decodedData[archivedKey])
+					s.Equal(float64(run.StartTime.Int64)/1000, decodedData[startTimeKey])
+					s.Equal(float64(run.EndTime.Int64)/1000, decodedData[endTimeKey])
 					responseCount++
 				} else {
-					assert.Nil(s.T(), decodedData[respNameKey])
-					assert.Nil(s.T(), decodedData[expIdKey])
-					assert.Nil(s.T(), decodedData[activeKey])
-					assert.Nil(s.T(), decodedData[archivedKey])
-					assert.Nil(s.T(), decodedData[startTimeKey])
-					assert.Nil(s.T(), decodedData[endTimeKey])
+					s.Nil(decodedData[respNameKey])
+					s.Nil(decodedData[expIdKey])
+					s.Nil(decodedData[activeKey])
+					s.Nil(decodedData[archivedKey])
+					s.Nil(decodedData[startTimeKey])
+					s.Nil(decodedData[endTimeKey])
 				}
 			}
-			assert.Equal(s.T(), tt.wantRunCount, responseCount)
+			s.Equal(tt.wantRunCount, responseCount)
 		})
 	}
 }

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
@@ -32,7 +30,7 @@ func TestSearchTestSuite(t *testing.T) {
 
 func (s *SearchTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +38,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -48,14 +46,14 @@ func (s *SearchTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
 		NamespaceID:    namespace.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create 3 different test runs and attach tags, metrics, params, etc.
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -77,13 +75,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag1",
 		RunID: run1.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     1.1,
@@ -93,13 +91,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run1.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
@@ -120,13 +118,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag2",
 		RunID: run2.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     2.1,
@@ -136,13 +134,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param2",
 		Value: "value2",
 		RunID: run2.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
@@ -163,13 +161,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag3",
 		RunID: run3.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     3.1,
@@ -179,13 +177,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run3.ID,
 		LastIter:  3,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param3",
 		Value: "value3",
 		RunID: run3.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run4, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id4",
@@ -206,13 +204,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri4",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag4",
 		RunID: run4.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "TestMetric",
 		Value:     4.1,
@@ -222,13 +220,13 @@ func (s *SearchTestSuite) Test_Ok() {
 		RunID:     run4.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param4",
 		Value: "value4",
 		RunID: run4.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs := []*models.Run{run1, run2, run3, run4}
 
@@ -774,8 +772,7 @@ func (s *SearchTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithResponseType(
 					helpers.ResponseTypeBuffer,
 				).WithQuery(
@@ -786,7 +783,7 @@ func (s *SearchTestSuite) Test_Ok() {
 			)
 
 			decodedData, err := encoding.Decode(resp)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			for _, run := range runs {
 				respNameKey := fmt.Sprintf("%v.props.name", run.ID)
@@ -796,20 +793,20 @@ func (s *SearchTestSuite) Test_Ok() {
 				activeKey := fmt.Sprintf("%v.props.active", run.ID)
 				archivedKey := fmt.Sprintf("%v.props.archived", run.ID)
 				if !slices.Contains(tt.runs, run) {
-					assert.Nil(s.T(), decodedData[respNameKey])
+					s.Nil(decodedData[respNameKey])
 				} else {
-					assert.Equal(s.T(), run.Name, decodedData[respNameKey])
-					assert.Equal(s.T(),
+					s.Equal(run.Name, decodedData[respNameKey])
+					s.Equal(
 						fmt.Sprintf("%v", run.ExperimentID),
 						decodedData[expIdKey])
-					assert.Equal(s.T(),
+					s.Equal(
 						run.Status == models.StatusRunning,
 						decodedData[activeKey])
-					assert.Equal(s.T(), run.LifecycleStage == models.LifecycleStageDeleted, decodedData[archivedKey])
-					assert.Equal(s.T(),
+					s.Equal(run.LifecycleStage == models.LifecycleStageDeleted, decodedData[archivedKey])
+					s.Equal(
 						run.StartTime.Int64,
 						int64(decodedData[startTimeKey].(float64)*1000))
-					assert.Equal(s.T(),
+					s.Equal(
 						run.EndTime.Int64,
 						int64(decodedData[endTimeKey].(float64)*1000))
 					metricCount := 0
@@ -817,14 +814,14 @@ func (s *SearchTestSuite) Test_Ok() {
 						metricNameKey := fmt.Sprintf("%v.traces.metric.%d.name", run.ID, metricCount)
 						metricValueKey := fmt.Sprintf("%v.traces.metric.%d.last_value.last", run.ID, metricCount)
 						metricStepKey := fmt.Sprintf("%v.traces.metric.%d.last_value.last_step", run.ID, metricCount)
-						assert.Equal(s.T(), metric.Value, decodedData[metricValueKey])
-						assert.Equal(s.T(), metric.LastIter, decodedData[metricStepKey])
-						assert.Equal(s.T(), metric.Key, decodedData[metricNameKey])
+						s.Equal(metric.Value, decodedData[metricValueKey])
+						s.Equal(metric.LastIter, decodedData[metricStepKey])
+						s.Equal(metric.Key, decodedData[metricNameKey])
 						metricCount++
 					}
 					for _, tag := range run.Tags {
 						tagKey := fmt.Sprintf("%v.params.tags.mlflow.runName", run.ID)
-						assert.Equal(s.T(), tag.Value, decodedData[tagKey])
+						s.Equal(tag.Value, decodedData[tagKey])
 					}
 				}
 			}

--- a/tests/integration/golang/aim/run/update_run_test.go
+++ b/tests/integration/golang/aim/run/update_run_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -36,22 +34,22 @@ func (s *UpdateRunTestSuite) SetupTest() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 }
 
 func (s *UpdateRunTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name    string
@@ -70,8 +68,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Success
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -83,18 +80,18 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 				),
 			)
 			run, err := s.RunFixtures.GetRun(context.Background(), s.run.ID)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			// TODO the PUT endpoint only updates LifecycleStage
-			// assert.Equal(t, newName, run.Name)
-			// assert.Equal(t, models.Status(newStatus), run.Status)
-			assert.Equal(s.T(), models.LifecycleStageDeleted, run.LifecycleStage)
+			// s.Equal(newName, run.Name)
+			// s.Equal(models.Status(newStatus), run.Status)
+			s.Equal(models.LifecycleStageDeleted, run.LifecycleStage)
 		})
 	}
 }
 
 func (s *UpdateRunTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	tests := []struct {
 		name        string
@@ -120,8 +117,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			var resp response.Error
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.AIMClient().WithMethod(
 					http.MethodPut,
 				).WithRequest(
@@ -132,7 +128,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 					"/runs/%s", tt.ID,
 				),
 			)
-			assert.Contains(s.T(), resp.Message, tt.error)
+			s.Contains(resp.Message, tt.error)
 		})
 	}
 }

--- a/tests/integration/golang/database/import_test.go
+++ b/tests/integration/golang/database/import_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -53,16 +51,16 @@ func (s *ImportTestSuite) SetupTest() {
 		1*time.Second,
 		20,
 	)
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), database.CheckAndMigrateDB(true, db.GormDB()))
-	require.Nil(s.T(), database.CreateDefaultNamespace(db.GormDB()))
-	require.Nil(s.T(), database.CreateDefaultExperiment(db.GormDB(), "s3://fasttrackml"))
+	s.Require().Nil(err)
+	s.Require().Nil(database.CheckAndMigrateDB(true, db.GormDB()))
+	s.Require().Nil(database.CreateDefaultNamespace(db.GormDB()))
+	s.Require().Nil(database.CreateDefaultExperiment(db.GormDB(), "s3://fasttrackml"))
 	s.inputDB = db.GormDB()
 
 	inputExperimentFixtures, err := fixtures.NewExperimentFixtures(db.GormDB())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	inputRunFixtures, err := fixtures.NewRunFixtures(db.GormDB())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.inputRunFixtures = inputRunFixtures
 
 	// experiment 1
@@ -71,10 +69,10 @@ func (s *ImportTestSuite) SetupTest() {
 		NamespaceID:    1,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs, err := inputRunFixtures.CreateExampleRuns(context.Background(), experiment, 5)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.runs = runs
 
 	// experiment 2
@@ -83,14 +81,14 @@ func (s *ImportTestSuite) SetupTest() {
 		NamespaceID:    1,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	runs, err = inputRunFixtures.CreateExampleRuns(context.Background(), experiment, 5)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.runs = runs
 
 	appFixtures, err := fixtures.NewAppFixtures(db.GormDB())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	app, err := appFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:        uuid.New(),
@@ -100,10 +98,10 @@ func (s *ImportTestSuite) SetupTest() {
 		Type:        "mpi",
 		State:       database.AppState{},
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	dashboardFixtures, err := fixtures.NewDashboardFixtures(db.GormDB())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// dashboard 1
 	_, err = dashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
@@ -114,7 +112,7 @@ func (s *ImportTestSuite) SetupTest() {
 		AppID: &app.ID,
 		Name:  uuid.NewString(),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// dashboard 2
 	_, err = dashboardFixtures.CreateDashboard(context.Background(), &database.Dashboard{
@@ -125,21 +123,21 @@ func (s *ImportTestSuite) SetupTest() {
 		AppID: &app.ID,
 		Name:  uuid.NewString(),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	// prepare output database.
 	db, err = database.NewDBProvider(
 		helpers.GetOutputDatabaseUri(),
 		1*time.Second,
 		20,
 	)
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), database.CheckAndMigrateDB(true, db.GormDB()))
-	require.Nil(s.T(), database.CreateDefaultNamespace(db.GormDB()))
-	require.Nil(s.T(), database.CreateDefaultExperiment(db.GormDB(), "s3://fasttrackml"))
+	s.Require().Nil(err)
+	s.Require().Nil(database.CheckAndMigrateDB(true, db.GormDB()))
+	s.Require().Nil(database.CreateDefaultNamespace(db.GormDB()))
+	s.Require().Nil(database.CreateDefaultExperiment(db.GormDB(), "s3://fasttrackml"))
 	s.outputDB = db.GormDB()
 
 	outputRunFixtures, err := fixtures.NewRunFixtures(db.GormDB())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.outputRunFixtures = outputRunFixtures
 
 	s.populatedRowCounts = rowCounts{
@@ -158,8 +156,8 @@ func (s *ImportTestSuite) SetupTest() {
 
 func (s *ImportTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.inputRunFixtures.UnloadFixtures())
-		require.Nil(s.T(), s.outputRunFixtures.UnloadFixtures())
+		s.Require().Nil(s.inputRunFixtures.UnloadFixtures())
+		s.Require().Nil(s.outputRunFixtures.UnloadFixtures())
 	}()
 
 	// source DB should have expected
@@ -170,13 +168,13 @@ func (s *ImportTestSuite) Test_Ok() {
 
 	// invoke the Importer.Import() method
 	importer := database.NewImporter(s.inputDB, s.outputDB)
-	require.Nil(s.T(), importer.Import())
+	s.Require().Nil(importer.Import())
 
 	// dest DB should now have the expected
 	s.validateRowCounts(s.outputDB, s.populatedRowCounts)
 
 	// invoke the Importer.Import method a 2nd time
-	require.Nil(s.T(), importer.Import())
+	s.Require().Nil(importer.Import())
 
 	// dest DB should still only have the expected
 	s.validateRowCounts(s.outputDB, s.populatedRowCounts)
@@ -202,45 +200,45 @@ func (s *ImportTestSuite) Test_Ok() {
 // assertions.
 func (s *ImportTestSuite) validateRowCounts(db *gorm.DB, counts rowCounts) {
 	var countVal int64
-	require.Nil(s.T(), db.Model(&models.Namespace{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.namespaces, int(countVal), "Namespaces count incorrect")
+	s.Require().Nil(db.Model(&models.Namespace{}).Count(&countVal).Error)
+	s.Equal(counts.namespaces, int(countVal), "Namespaces count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.Experiment{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.experiments, int(countVal), "Experiments count incorrect")
+	s.Require().Nil(db.Model(&models.Experiment{}).Count(&countVal).Error)
+	s.Equal(counts.experiments, int(countVal), "Experiments count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.Run{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.runs, int(countVal), "Runs count incorrect")
+	s.Require().Nil(db.Model(&models.Run{}).Count(&countVal).Error)
+	s.Equal(counts.runs, int(countVal), "Runs count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.Metric{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.metrics, int(countVal), "Metrics count incorrect")
+	s.Require().Nil(db.Model(&models.Metric{}).Count(&countVal).Error)
+	s.Equal(counts.metrics, int(countVal), "Metrics count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.LatestMetric{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.latestMetrics, int(countVal), "Latest metrics count incorrect")
+	s.Require().Nil(db.Model(&models.LatestMetric{}).Count(&countVal).Error)
+	s.Equal(counts.latestMetrics, int(countVal), "Latest metrics count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.Tag{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.tags, int(countVal), "Run tags count incorrect")
+	s.Require().Nil(db.Model(&models.Tag{}).Count(&countVal).Error)
+	s.Equal(counts.tags, int(countVal), "Run tags count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.Param{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.params, int(countVal), "Run params count incorrect")
+	s.Require().Nil(db.Model(&models.Param{}).Count(&countVal).Error)
+	s.Equal(counts.params, int(countVal), "Run params count incorrect")
 
-	require.Nil(s.T(), db.Model(&models.Run{}).Distinct("experiment_id").Count(&countVal).Error)
-	assert.Equal(s.T(), counts.distinctRunExperimentIDs, int(countVal), "Runs experiment association incorrect")
+	s.Require().Nil(db.Model(&models.Run{}).Distinct("experiment_id").Count(&countVal).Error)
+	s.Equal(counts.distinctRunExperimentIDs, int(countVal), "Runs experiment association incorrect")
 
-	require.Nil(s.T(), db.Model(&database.App{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.apps, int(countVal), "Apps count incorrect")
+	s.Require().Nil(db.Model(&database.App{}).Count(&countVal).Error)
+	s.Equal(counts.apps, int(countVal), "Apps count incorrect")
 
-	require.Nil(s.T(), db.Model(&database.Dashboard{}).Count(&countVal).Error)
-	assert.Equal(s.T(), counts.dashboards, int(countVal), "Dashboard count incorrect")
+	s.Require().Nil(db.Model(&database.Dashboard{}).Count(&countVal).Error)
+	s.Equal(counts.dashboards, int(countVal), "Dashboard count incorrect")
 }
 
 // validateTable will scan source and dest table and confirm they are identical
 func (s *ImportTestSuite) validateTable(source, dest *gorm.DB, table string) {
 	sourceRows, err := source.Table(table).Rows()
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), sourceRows.Err())
+	s.Require().Nil(err)
+	s.Require().Nil(sourceRows.Err())
 	destRows, err := dest.Table(table).Rows()
-	require.Nil(s.T(), err)
-	require.Nil(s.T(), destRows.Err())
+	s.Require().Nil(err)
+	s.Require().Nil(destRows.Err())
 	//nolint:errcheck
 	defer sourceRows.Close()
 	//nolint:errcheck
@@ -248,11 +246,11 @@ func (s *ImportTestSuite) validateTable(source, dest *gorm.DB, table string) {
 
 	for sourceRows.Next() {
 		// dest should have the same number of rows as source
-		require.True(s.T(), destRows.Next())
+		s.Require().True(destRows.Next())
 
 		var sourceRow, destRow map[string]any
-		require.Nil(s.T(), source.ScanRows(sourceRows, &sourceRow))
-		require.Nil(s.T(), dest.ScanRows(destRows, &destRow))
+		s.Require().Nil(source.ScanRows(sourceRows, &sourceRow))
+		s.Require().Nil(dest.ScanRows(destRows, &destRow))
 
 		// TODO:DSuhinin delete this fields right now, because they
 		// cause comparison error when we compare `namespace` entities. Let's find smarter way to do that.
@@ -261,8 +259,8 @@ func (s *ImportTestSuite) validateTable(source, dest *gorm.DB, table string) {
 		delete(sourceRow, "updated_at")
 		delete(sourceRow, "created_at")
 
-		assert.Equal(s.T(), sourceRow, destRow)
+		s.Equal(sourceRow, destRow)
 	}
 	// dest should have the same number of rows as source
-	require.False(s.T(), destRows.Next())
+	s.Require().False(destRows.Next())
 }

--- a/tests/integration/golang/database/migrate_test.go
+++ b/tests/integration/golang/database/migrate_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/database"
@@ -43,15 +42,15 @@ func (s *MigrateTestSuite) TestMigrate() {
 			// setup sqlite MLFlow database from the schema
 			mlflowDBPath := path.Join(s.T().TempDir(), "mlflow.db")
 			mlflowDB, err := sql.Open("sqlite3", mlflowDBPath)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			//nolint:gosec
 			mlflowSql, err := os.ReadFile(tt.schema)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			_, err = mlflowDB.Exec(string(mlflowSql))
-			require.Nil(s.T(), err)
-			require.Nil(s.T(), mlflowDB.Close())
+			s.Require().Nil(err)
+			s.Require().Nil(mlflowDB.Close())
 
 			// make DbProvider using our package
 			db, err := database.NewDBProvider(
@@ -59,10 +58,10 @@ func (s *MigrateTestSuite) TestMigrate() {
 				1*time.Second,
 				20,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// run migrations
-			require.Nil(s.T(), database.CheckAndMigrateDB(true, db.GormDB()))
+			s.Require().Nil(database.CheckAndMigrateDB(true, db.GormDB()))
 		})
 	}
 }

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
@@ -36,7 +35,7 @@ func (s *BaseTestSuite) SetupTest() {
 			1*time.Second,
 			20,
 		)
-		require.Nil(s.T(), err)
+		s.Require().Nil(err)
 		db = instance.GormDB()
 	}
 
@@ -51,41 +50,41 @@ func (s *BaseTestSuite) SetupTest() {
 	}
 
 	appFixtures, err := fixtures.NewAppFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.AppFixtures = appFixtures
 
 	dashboardFixtures, err := fixtures.NewDashboardFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.DashboardFixtures = dashboardFixtures
 
 	experimentFixtures, err := fixtures.NewExperimentFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.ExperimentFixtures = experimentFixtures
 
 	metricFixtures, err := fixtures.NewMetricFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.MetricFixtures = metricFixtures
 
 	namespaceFixtures, err := fixtures.NewNamespaceFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.NamespaceFixtures = namespaceFixtures
 
 	projectFixtures, err := fixtures.NewProjectFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.ProjectFixtures = projectFixtures
 
 	paramFixtures, err := fixtures.NewParamFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.ParamFixtures = paramFixtures
 
 	runFixtures, err := fixtures.NewRunFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.RunFixtures = runFixtures
 
 	tagFixtures, err := fixtures.NewTagFixtures(db)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	s.TagFixtures = tagFixtures
 
 	// by default, unload everything.
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }

--- a/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -35,7 +33,7 @@ func TestGetArtifactLocalTestSuite(t *testing.T) {
 
 func (s *GetArtifactLocalTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -43,7 +41,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name   string
@@ -69,7 +67,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("%s%s", tt.prefix, experimentArtifactDir),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -82,17 +80,17 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s%s", tt.prefix, runArtifactDir),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 3. create artifacts.
 			err = os.MkdirAll(runArtifactDir, fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.file1"), []byte("contentX"), fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			err = os.Mkdir(filepath.Join(runArtifactDir, "artifact.dir"), fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.dir", "artifact.file2"), []byte("contentXX"), fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 4. make actual API call for root dir file
 			rootFileQuery := request.GetArtifactRequest{
@@ -101,7 +99,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			resp := new(bytes.Buffer)
-			require.Nil(s.T(), s.MlflowClient().WithQuery(
+			s.Require().Nil(s.MlflowClient().WithQuery(
 				rootFileQuery,
 			).WithResponseType(
 				helpers.ResponseTypeBuffer,
@@ -110,7 +108,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			).DoRequest(
 				"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsGetRoute,
 			))
-			assert.Equal(s.T(), "contentX", resp.String())
+			s.Equal("contentX", resp.String())
 
 			// 5. make actual API call for sub dir file
 			subDirQuery := request.GetArtifactRequest{
@@ -119,7 +117,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			resp = new(bytes.Buffer)
-			require.Nil(s.T(), s.MlflowClient().WithQuery(
+			s.Require().Nil(s.MlflowClient().WithQuery(
 				subDirQuery,
 			).WithResponseType(
 				helpers.ResponseTypeBuffer,
@@ -128,14 +126,14 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			).DoRequest(
 				"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsGetRoute,
 			))
-			assert.Equal(s.T(), "contentXX", resp.String())
+			s.Equal("contentXX", resp.String())
 		})
 	}
 }
 
 func (s *GetArtifactLocalTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -143,7 +141,7 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test experiment
 	experimentArtifactDir := s.T().TempDir()
@@ -153,7 +151,7 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: experimentArtifactDir,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test run
 	runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -166,10 +164,10 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 		ArtifactURI:    runArtifactDir,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	err = os.MkdirAll(filepath.Join(runArtifactDir, "subdir"), fs.ModePerm)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -254,14 +252,14 @@ func (s *GetArtifactLocalTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(s.T(), s.MlflowClient().WithQuery(
+			s.Require().Nil(s.MlflowClient().WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,
 			).DoRequest(
 				"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsGetRoute,
 			))
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/artifact/list_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_local_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -37,7 +35,7 @@ func TestListArtifactLocalTestSuite(t *testing.T) {
 
 func (s *ListArtifactLocalTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -45,7 +43,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name   string
@@ -85,7 +83,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("%s%s", tt.prefix, experimentArtifactDir),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -98,19 +96,19 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s%s", tt.prefix, runArtifactDir),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 3. create artifacts.
 			err = os.MkdirAll(runArtifactDir, fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			err = os.WriteFile(filepath.Join(runArtifactDir, "artifact.file1"), []byte("contentX"), fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			err = os.Mkdir(filepath.Join(runArtifactDir, "artifact.dir"), fs.ModePerm)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			err = os.WriteFile(
 				filepath.Join(runArtifactDir, "artifact.dir", "artifact.file2"), []byte("contentXX"), fs.ModePerm,
 			)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 4. make actual API call for root dir.
 			rootDirQuery := request.ListArtifactsRequest{
@@ -118,8 +116,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			rootDirResp := response.ListArtifactsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					rootDirQuery,
 				).WithResponse(
@@ -129,9 +126,9 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				),
 			)
 
-			assert.Equal(s.T(), run.ArtifactURI, rootDirResp.RootURI)
-			assert.Equal(s.T(), 2, len(rootDirResp.Files))
-			assert.Equal(s.T(), []response.FilePartialResponse{
+			s.Equal(run.ArtifactURI, rootDirResp.RootURI)
+			s.Equal(2, len(rootDirResp.Files))
+			s.Equal([]response.FilePartialResponse{
 				{
 					Path:     "artifact.dir",
 					IsDir:    true,
@@ -143,7 +140,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 					FileSize: 8,
 				},
 			}, rootDirResp.Files)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 5. make actual API call for sub dir.
 			subDirQuery := request.ListArtifactsRequest{
@@ -152,8 +149,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			subDirResp := response.ListArtifactsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					subDirQuery,
 				).WithResponse(
@@ -163,14 +159,14 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				),
 			)
 
-			assert.Equal(s.T(), run.ArtifactURI, subDirResp.RootURI)
-			assert.Equal(s.T(), 1, len(subDirResp.Files))
-			assert.Equal(s.T(), response.FilePartialResponse{
+			s.Equal(run.ArtifactURI, subDirResp.RootURI)
+			s.Equal(1, len(subDirResp.Files))
+			s.Equal(response.FilePartialResponse{
 				Path:     "artifact.dir/artifact.file2",
 				IsDir:    false,
 				FileSize: 9,
 			}, subDirResp.Files[0])
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 6. make actual API call for non-existing dir.
 			nonExistingDirQuery := request.ListArtifactsRequest{
@@ -179,8 +175,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			}
 
 			nonExistingDirResp := response.ListArtifactsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					nonExistingDirQuery,
 				).WithResponse(
@@ -190,16 +185,16 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 				),
 			)
 
-			assert.Equal(s.T(), run.ArtifactURI, nonExistingDirResp.RootURI)
-			assert.Equal(s.T(), 0, len(nonExistingDirResp.Files))
-			require.Nil(s.T(), err)
+			s.Equal(run.ArtifactURI, nonExistingDirResp.RootURI)
+			s.Equal(0, len(nonExistingDirResp.Files))
+			s.Require().Nil(err)
 		})
 	}
 }
 
 func (s *ListArtifactLocalTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -207,7 +202,7 @@ func (s *ListArtifactLocalTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -264,14 +259,14 @@ func (s *ListArtifactLocalTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(s.T(), s.MlflowClient().WithQuery(
+			s.Require().Nil(s.MlflowClient().WithQuery(
 				tt.request,
 			).WithResponse(
 				&resp,
 			).DoRequest(
 				"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsListRoute),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -42,22 +40,22 @@ func (s *ListArtifactS3TestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
 	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	err = helpers.CreateS3Buckets(s3Client, s.testBuckets)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.s3Client = s3Client
 }
 
 func (s *ListArtifactS3TestSuite) TearDownTest() {
 	err := helpers.RemoveS3Buckets(s.s3Client, s.testBuckets)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 }
 
 func (s *ListArtifactS3TestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -65,7 +63,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name   string
@@ -104,7 +102,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("s3://%s/1", tt.bucket),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. create test run.
 			runID := strings.ReplaceAll(uuid.New().String(), "-", "")
@@ -116,7 +114,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				ArtifactURI:    fmt.Sprintf("%s/%s/artifacts", experiment.ArtifactLocation, runID),
 				LifecycleStage: models.LifecycleStageActive,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 3. upload artifact objects to S3.
 			_, err = s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
@@ -124,13 +122,13 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				Body:   strings.NewReader("contentX"),
 				Bucket: aws.String(tt.bucket),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			_, err = s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
 				Key:    aws.String(fmt.Sprintf("1/%s/artifacts/artifact.dir/artifact.file2", runID)),
 				Body:   strings.NewReader("contentXX"),
 				Bucket: aws.String(tt.bucket),
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 4. make actual API call for root dir.
 			rootDirQuery := request.ListArtifactsRequest{
@@ -138,8 +136,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 			}
 
 			rootDirResp := response.ListArtifactsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					rootDirQuery,
 				).WithResponse(
@@ -149,9 +146,9 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				),
 			)
 
-			assert.Equal(s.T(), run.ArtifactURI, rootDirResp.RootURI)
-			assert.Equal(s.T(), 2, len(rootDirResp.Files))
-			assert.Equal(s.T(), []response.FilePartialResponse{
+			s.Equal(run.ArtifactURI, rootDirResp.RootURI)
+			s.Equal(2, len(rootDirResp.Files))
+			s.Equal([]response.FilePartialResponse{
 				{
 					Path:     "artifact.dir",
 					IsDir:    true,
@@ -171,8 +168,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 			}
 
 			subDirResp := response.ListArtifactsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					subDirQuery,
 				).WithResponse(
@@ -182,25 +178,24 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				),
 			)
 
-			assert.Equal(s.T(), run.ArtifactURI, subDirResp.RootURI)
-			assert.Equal(s.T(), 1, len(subDirResp.Files))
-			assert.Equal(s.T(), response.FilePartialResponse{
+			s.Equal(run.ArtifactURI, subDirResp.RootURI)
+			s.Equal(1, len(subDirResp.Files))
+			s.Equal(response.FilePartialResponse{
 				Path:     "artifact.dir/artifact.file2",
 				IsDir:    false,
 				FileSize: 9,
 			}, subDirResp.Files[0])
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 6. make actual API call for non-existing dir.
 			nonExistingDirQuery := request.ListArtifactsRequest{
 				RunID: run.ID,
 				Path:  "non-existing-dir",
 			}
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			nonExistingDirResp := response.ListArtifactsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					nonExistingDirQuery,
 				).WithResponse(
@@ -210,16 +205,16 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 				),
 			)
 
-			assert.Equal(s.T(), run.ArtifactURI, nonExistingDirResp.RootURI)
-			assert.Equal(s.T(), 0, len(nonExistingDirResp.Files))
-			require.Nil(s.T(), err)
+			s.Equal(run.ArtifactURI, nonExistingDirResp.RootURI)
+			s.Equal(0, len(nonExistingDirResp.Files))
+			s.Require().Nil(err)
 		})
 	}
 }
 
 func (s *ListArtifactS3TestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -227,7 +222,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -284,8 +279,7 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -294,8 +288,8 @@ func (s *ListArtifactS3TestSuite) Test_Error() {
 					"%s%s", mlflow.ArtifactsRoutePrefix, mlflow.ArtifactsListRoute,
 				),
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Require().Nil(err)
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/create_test.go
+++ b/tests/integration/golang/mlflow/experiment/create_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -30,7 +28,7 @@ func TestCreateExperimentTestSuite(t *testing.T) {
 
 func (s *CreateExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -38,7 +36,7 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.CreateExperimentRequest{
 		Name:             "ExperimentName",
@@ -55,8 +53,7 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 		},
 	}
 	resp := response.CreateExperimentResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -67,12 +64,12 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 			"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsCreateRoute,
 		),
 	)
-	assert.NotEmpty(s.T(), resp.ID)
+	s.NotEmpty(resp.ID)
 }
 
 func (s *CreateExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -80,7 +77,7 @@ func (s *CreateExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -108,8 +105,7 @@ func (s *CreateExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -120,7 +116,7 @@ func (s *CreateExperimentTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsCreateRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/delete_test.go
+++ b/tests/integration/golang/mlflow/experiment/delete_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -33,7 +31,7 @@ func TestDeleteExperimentTestSuite(t *testing.T) {
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -41,7 +39,7 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -63,18 +61,17 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// check that the experiment lifecycle is active
-	assert.Equal(s.T(), models.LifecycleStageActive, experiment.LifecycleStage)
+	s.Equal(models.LifecycleStageActive, experiment.LifecycleStage)
 
 	// 2. make actual API call.
 	req := request.DeleteExperimentRequest{
 		ID: fmt.Sprintf("%d", *experiment.ID),
 	}
 	resp := fiber.Map{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -90,13 +87,13 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), models.LifecycleStageDeleted, exp.LifecycleStage)
+	s.Require().Nil(err)
+	s.Equal(models.LifecycleStageDeleted, exp.LifecycleStage)
 }
 
 func (s *DeleteExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -104,7 +101,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -141,8 +138,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -153,7 +149,7 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsDeleteRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/get_by_name_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_by_name_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestGetExperimentByNameTestSuite(t *testing.T) {
 
 func (s *GetExperimentByNameTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +38,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -62,7 +60,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// 2. make actual API call.
 	request := request.GetExperimentRequest{
@@ -70,8 +68,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetExperimentResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithQuery(
 			request,
 		).WithResponse(
@@ -82,11 +79,11 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 	)
 
 	// 3. check actual API response.
-	assert.Equal(s.T(), fmt.Sprintf("%d", *experiment.ID), resp.Experiment.ID)
-	assert.Equal(s.T(), experiment.Name, resp.Experiment.Name)
-	assert.Equal(s.T(), string(experiment.LifecycleStage), resp.Experiment.LifecycleStage)
-	assert.Equal(s.T(), experiment.ArtifactLocation, resp.Experiment.ArtifactLocation)
-	assert.Equal(s.T(), []models.ExperimentTag{
+	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.Experiment.ID)
+	s.Equal(experiment.Name, resp.Experiment.Name)
+	s.Equal(string(experiment.LifecycleStage), resp.Experiment.LifecycleStage)
+	s.Equal(experiment.ArtifactLocation, resp.Experiment.ArtifactLocation)
+	s.Equal([]models.ExperimentTag{
 		{
 			Key:          "key1",
 			Value:        "value1",
@@ -97,7 +94,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 
 func (s *GetExperimentByNameTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -105,7 +102,7 @@ func (s *GetExperimentByNameTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -131,8 +128,7 @@ func (s *GetExperimentByNameTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -141,7 +137,7 @@ func (s *GetExperimentByNameTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsGetByNameRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/get_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestGetExperimentTestSuite(t *testing.T) {
 
 func (s *GetExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// 1. prepare database with test data.
@@ -41,7 +39,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -63,7 +61,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// 2. make actual API call.
 	request := request.GetExperimentRequest{
@@ -71,8 +69,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetExperimentResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithQuery(
 			request,
 		).WithResponse(
@@ -82,11 +79,11 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 		),
 	)
 	// 3. check actual API response.
-	assert.Equal(s.T(), fmt.Sprintf("%d", *experiment.ID), resp.Experiment.ID)
-	assert.Equal(s.T(), experiment.Name, resp.Experiment.Name)
-	assert.Equal(s.T(), string(experiment.LifecycleStage), resp.Experiment.LifecycleStage)
-	assert.Equal(s.T(), experiment.ArtifactLocation, resp.Experiment.ArtifactLocation)
-	assert.Equal(s.T(), []models.ExperimentTag{
+	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.Experiment.ID)
+	s.Equal(experiment.Name, resp.Experiment.Name)
+	s.Equal(string(experiment.LifecycleStage), resp.Experiment.LifecycleStage)
+	s.Equal(experiment.ArtifactLocation, resp.Experiment.ArtifactLocation)
+	s.Equal([]models.ExperimentTag{
 		{
 			Key:          "key1",
 			Value:        "value1",
@@ -97,7 +94,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 
 func (s *GetExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -105,7 +102,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -136,8 +133,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -146,7 +142,7 @@ func (s *GetExperimentTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsGetRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/restore_test.go
+++ b/tests/integration/golang/mlflow/experiment/restore_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -33,7 +31,7 @@ func TestRestoreExperimentTestSuite(t *testing.T) {
 
 func (s *RestoreExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -41,7 +39,7 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
@@ -63,16 +61,15 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageDeleted,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), models.LifecycleStageDeleted, experiment.LifecycleStage)
+	s.Require().Nil(err)
+	s.Equal(models.LifecycleStageDeleted, experiment.LifecycleStage)
 
 	// 2. make actual API call.
 	req := request.RestoreExperimentRequest{
 		ID: fmt.Sprintf("%d", *experiment.ID),
 	}
 	resp := fiber.Map{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -88,13 +85,13 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), models.LifecycleStageActive, exp.LifecycleStage)
+	s.Require().Nil(err)
+	s.Equal(models.LifecycleStageActive, exp.LifecycleStage)
 }
 
 func (s *RestoreExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -102,7 +99,7 @@ func (s *RestoreExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -139,8 +136,7 @@ func (s *RestoreExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -151,7 +147,7 @@ func (s *RestoreExperimentTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsRestoreRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/search_test.go
+++ b/tests/integration/golang/mlflow/experiment/search_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -31,7 +29,7 @@ func TestSearchExperimentsTestSuite(t *testing.T) {
 
 func (s *SearchExperimentsTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -39,7 +37,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiments := []models.Experiment{
 		{
@@ -110,7 +108,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 			LifecycleStage:   ex.LifecycleStage,
 			ArtifactLocation: "/artifact/location",
 		})
-		require.Nil(s.T(), err)
+		s.Require().Nil(err)
 	}
 
 	tests := []struct {
@@ -163,8 +161,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := response.SearchExperimentsResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -179,14 +176,14 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 				names[i] = exp.Name
 			}
 
-			assert.ElementsMatch(s.T(), tt.expected, names)
+			s.ElementsMatch(tt.expected, names)
 		})
 	}
 }
 
 func (s *SearchExperimentsTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -194,7 +191,7 @@ func (s *SearchExperimentsTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -274,8 +271,7 @@ func (s *SearchExperimentsTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -284,7 +280,7 @@ func (s *SearchExperimentsTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsSearchRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
+++ b/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestSetExperimentTagTestSuite(t *testing.T) {
 
 func (s *SetExperimentTagTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +38,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:        "Test Experiment",
@@ -56,7 +54,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:        "Test Experiment2",
 		NamespaceID: namespace.ID,
@@ -71,7 +69,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// Set tag on experiment1
 	req := request.SetExperimentTagRequest{
@@ -79,8 +77,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Key:   "KeyTag1",
 		Value: "ValueTag1",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -93,8 +90,8 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment1, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment1.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.True(s.T(), helpers.CheckTagExists(
+	s.Require().Nil(err)
+	s.True(helpers.CheckTagExists(
 		experiment1.Tags, "KeyTag1", "ValueTag1"), "Expected 'experiment.tags' to contain 'KeyTag1' with value 'ValueTag1'",
 	)
 
@@ -104,8 +101,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Key:   "KeyTag1",
 		Value: "ValueTag2",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -118,9 +114,8 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment1, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment1.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.True(
-		s.T(),
+	s.Require().Nil(err)
+	s.True(
 		helpers.CheckTagExists(experiment1.Tags, "KeyTag1", "ValueTag2"),
 		"Expected 'experiment.tags' to contain 'KeyTag1' with value 'ValueTag1'",
 	)
@@ -129,8 +124,8 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment2, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment2.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), len(experiment2.Tags), 0)
+	s.Require().Nil(err)
+	s.Equal(len(experiment2.Tags), 0)
 
 	// test that setting a tag on different experiments maintain different values across experiments
 	req = request.SetExperimentTagRequest{
@@ -138,8 +133,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 		Key:   "KeyTag1",
 		Value: "ValueTag3",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -151,18 +145,17 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 	experiment1, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment1.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.True(
-		s.T(), helpers.CheckTagExists(experiment1.Tags, "KeyTag1", "ValueTag2"),
+	s.Require().Nil(err)
+	s.True(
+		helpers.CheckTagExists(experiment1.Tags, "KeyTag1", "ValueTag2"),
 		"Expected 'experiment1.tags' to contain 'KeyTag1' with value 'ValueTag2'",
 	)
 
 	experiment2, err = s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment2.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.True(
-		s.T(),
+	s.Require().Nil(err)
+	s.True(
 		helpers.CheckTagExists(experiment2.Tags, "KeyTag1", "ValueTag3"),
 		"Expected 'experiment1.tags' to contain 'KeyTag1' with value 'ValueTag3'",
 	)
@@ -170,7 +163,7 @@ func (s *SetExperimentTagTestSuite) Test_Ok() {
 
 func (s *SetExperimentTagTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -178,7 +171,7 @@ func (s *SetExperimentTagTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -226,8 +219,7 @@ func (s *SetExperimentTagTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -238,7 +230,7 @@ func (s *SetExperimentTagTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsSetExperimentTag,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/experiment/update_test.go
+++ b/tests/integration/golang/mlflow/experiment/update_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestUpdateExperimentTestSuite(t *testing.T) {
 
 func (s *UpdateExperimentTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	// 1. prepare database with test data.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +38,7 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:        "Test Experiment",
@@ -56,14 +54,13 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.UpdateExperimentRequest{
 		ID:   fmt.Sprintf("%d", *experiment.ID),
 		Name: "Test Updated Experiment",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -78,13 +75,13 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
 		context.Background(), namespace.ID, *experiment.ID,
 	)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), "Test Updated Experiment", exp.Name)
+	s.Require().Nil(err)
+	s.Equal("Test Updated Experiment", exp.Name)
 }
 
 func (s *UpdateExperimentTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -92,7 +89,7 @@ func (s *UpdateExperimentTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -129,8 +126,7 @@ func (s *UpdateExperimentTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -141,7 +137,7 @@ func (s *UpdateExperimentTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsUpdateRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,14 +30,14 @@ func TestGetHistoriesTestSuite(t *testing.T) {
 
 func (s *GetHistoriesTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment",
@@ -47,7 +45,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run1",
@@ -57,7 +55,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -68,7 +66,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run2",
@@ -78,7 +76,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -89,7 +87,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -111,8 +109,7 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := new(bytes.Buffer)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -128,14 +125,14 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 
 			// TODO:DSuhinin - data is encoded so we need a bit more smart way to check the data.
 			// right now we can go with this simple approach.
-			assert.NotEmpty(s.T(), resp.String())
+			s.NotEmpty(resp.String())
 		})
 	}
 }
 
 func (s *GetHistoriesTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -143,7 +140,7 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -181,8 +178,7 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -193,8 +189,8 @@ func (s *GetHistoriesTestSuite) Test_Error() {
 					"%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoriesRoute,
 				),
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Require().Nil(err)
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -30,14 +28,14 @@ func TestGetHistoriesBulkTestSuite(t *testing.T) {
 
 func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment",
@@ -45,7 +43,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run1, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run1",
@@ -55,7 +53,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -66,7 +64,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "run2",
@@ -76,7 +74,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -87,7 +85,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.GetMetricHistoryBulkRequest{
 		RunIDs:    []string{run1.ID, run2.ID},
@@ -95,8 +93,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetMetricHistoryResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithQuery(
 			req,
 		).WithResponse(
@@ -106,7 +103,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 		),
 	)
 
-	assert.Equal(s.T(), response.GetMetricHistoryResponse{
+	s.Equal(response.GetMetricHistoryResponse{
 		Metrics: []response.MetricPartialResponse{
 			{
 				RunID:     run1.ID,
@@ -128,7 +125,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 
 func (s *GetHistoriesBulkTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -136,7 +133,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -168,8 +165,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -178,7 +174,7 @@ func (s *GetHistoriesBulkTestSuite) Test_Error() {
 					"%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoryBulkRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -29,14 +27,14 @@ func TestGetHistoryTestSuite(t *testing.T) {
 
 func (s *GetHistoryTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  1,
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment",
@@ -44,7 +42,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "/artifact/location",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             "id",
@@ -54,7 +52,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		ExperimentID:   *experiment.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.MetricFixtures.CreateMetric(context.Background(), &models.Metric{
 		Key:       "key1",
@@ -65,7 +63,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 		IsNan:     false,
 		Iter:      1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.GetMetricHistoryRequest{
 		RunID:     run.ID,
@@ -73,8 +71,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 	}
 
 	resp := response.GetMetricHistoryResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithQuery(
 			req,
 		).WithResponse(
@@ -83,7 +80,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 			"%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoryRoute,
 		),
 	)
-	assert.Equal(s.T(), response.GetMetricHistoryResponse{
+	s.Equal(response.GetMetricHistoryResponse{
 		Metrics: []response.MetricPartialResponse{
 			{
 				Key:       "key1",
@@ -97,7 +94,7 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 
 func (s *GetHistoryTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -105,7 +102,7 @@ func (s *GetHistoryTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -128,8 +125,7 @@ func (s *GetHistoryTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -138,7 +134,7 @@ func (s *GetHistoryTestSuite) Test_Error() {
 					"%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoryRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/namespace/flows/metric_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/metric_test.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -34,7 +32,7 @@ func TestMetricFlowTestSuite(t *testing.T) {
 }
 
 func (s *MetricFlowTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *MetricFlowTestSuite) Test_Ok() {
@@ -90,14 +88,14 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			namespace2, err = s.NamespaceFixtures.CreateNamespace(context.Background(), namespace2)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment1",
@@ -105,7 +103,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace1.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             "Experiment2",
@@ -113,7 +111,7 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 				LifecycleStage:   models.LifecycleStageActive,
 				NamespaceID:      namespace2.ID,
 			})
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 
 			// 2. run actual flow test over the test data.
 			s.testRunMetricFlow(tt.namespace1Code, tt.namespace2Code, experiment1, experiment2)
@@ -327,8 +325,7 @@ func (s *MetricFlowTestSuite) createRun(
 	namespace string, req *request.CreateRunRequest,
 ) string {
 	resp := response.CreateRunResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -348,8 +345,7 @@ func (s *MetricFlowTestSuite) getRunAndCompare(
 	namespace string, req request.GetRunRequest, expectedResponse *response.GetRunResponse,
 ) {
 	resp := response.GetRunResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithNamespace(
 			namespace,
 		).WithQuery(
@@ -360,26 +356,25 @@ func (s *MetricFlowTestSuite) getRunAndCompare(
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsGetRoute,
 		),
 	)
-	assert.Equal(s.T(), expectedResponse.Run.Info.ID, resp.Run.Info.ID)
-	assert.Equal(s.T(), expectedResponse.Run.Info.Name, resp.Run.Info.Name)
-	assert.Equal(s.T(), expectedResponse.Run.Info.Status, resp.Run.Info.Status)
-	assert.Equal(s.T(), expectedResponse.Run.Info.ArtifactURI, resp.Run.Info.ArtifactURI)
-	assert.Equal(s.T(), expectedResponse.Run.Info.ExperimentID, resp.Run.Info.ExperimentID)
-	assert.Equal(s.T(), expectedResponse.Run.Info.LifecycleStage, resp.Run.Info.LifecycleStage)
+	s.Equal(expectedResponse.Run.Info.ID, resp.Run.Info.ID)
+	s.Equal(expectedResponse.Run.Info.Name, resp.Run.Info.Name)
+	s.Equal(expectedResponse.Run.Info.Status, resp.Run.Info.Status)
+	s.Equal(expectedResponse.Run.Info.ArtifactURI, resp.Run.Info.ArtifactURI)
+	s.Equal(expectedResponse.Run.Info.ExperimentID, resp.Run.Info.ExperimentID)
+	s.Equal(expectedResponse.Run.Info.LifecycleStage, resp.Run.Info.LifecycleStage)
 	if expectedResponse.Run.Data.Tags != nil {
-		assert.Equal(s.T(), expectedResponse.Run.Data.Tags, resp.Run.Data.Tags)
+		s.Equal(expectedResponse.Run.Data.Tags, resp.Run.Data.Tags)
 	}
 	if expectedResponse.Run.Data.Params != nil {
-		assert.Equal(s.T(), expectedResponse.Run.Data.Params, resp.Run.Data.Params)
+		s.Equal(expectedResponse.Run.Data.Params, resp.Run.Data.Params)
 	}
 	if expectedResponse.Run.Data.Metrics != nil {
-		assert.Equal(s.T(), expectedResponse.Run.Data.Metrics, resp.Run.Data.Metrics)
+		s.Equal(expectedResponse.Run.Data.Metrics, resp.Run.Data.Metrics)
 	}
 }
 
 func (s *MetricFlowTestSuite) logRunMetric(namespace string, req *request.LogMetricRequest) {
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithNamespace(
@@ -396,8 +391,7 @@ func (s *MetricFlowTestSuite) getMetricHistoryBulkAndCompare(
 	namespace string, req request.GetMetricHistoryBulkRequest, expectedResponse response.GetMetricHistoryResponse,
 ) {
 	actualResponse := response.GetMetricHistoryResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithNamespace(
 			namespace,
 		).WithQuery(
@@ -408,15 +402,14 @@ func (s *MetricFlowTestSuite) getMetricHistoryBulkAndCompare(
 			"%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoryBulkRoute,
 		),
 	)
-	assert.Equal(s.T(), expectedResponse, actualResponse)
+	s.Equal(expectedResponse, actualResponse)
 }
 
 func (s *MetricFlowTestSuite) getMetricHistoryAndCompare(
 	namespace string, req request.GetMetricHistoryRequest, expectedResponse response.GetMetricHistoryResponse,
 ) {
 	actualResponse := response.GetMetricHistoryResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithNamespace(
 			namespace,
 		).WithQuery(
@@ -427,5 +420,5 @@ func (s *MetricFlowTestSuite) getMetricHistoryAndCompare(
 			"%s%s", mlflow.MetricsRoutePrefix, mlflow.MetricsGetHistoryRoute,
 		),
 	)
-	assert.Equal(s.T(), expectedResponse, actualResponse)
+	s.Equal(expectedResponse, actualResponse)
 }

--- a/tests/integration/golang/mlflow/namespace/namespace_test.go
+++ b/tests/integration/golang/mlflow/namespace/namespace_test.go
@@ -5,8 +5,6 @@ package namespace
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -24,7 +22,7 @@ func TestNamespaceTestSuite(t *testing.T) {
 }
 
 func (s *NamespaceTestSuite) TearDownTest() {
-	require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 }
 
 func (s *NamespaceTestSuite) Test_Error() {
@@ -51,8 +49,7 @@ func (s *NamespaceTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithNamespace(
 					tt.namespace,
 				).WithQuery(
@@ -63,8 +60,8 @@ func (s *NamespaceTestSuite) Test_Error() {
 					"%s%s", mlflow.ExperimentsRoutePrefix, mlflow.ExperimentsGetRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
-			assert.Equal(s.T(), api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
+			s.Equal(tt.error.Error(), resp.Error())
+			s.Equal(api.ErrorCodeResourceDoesNotExist, string(resp.ErrorCode))
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestCreateRunTestSuite(t *testing.T) {
 
 func (s *CreateRunTestSuite) Test_DefaultNamespace_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -41,21 +39,21 @@ func (s *CreateRunTestSuite) Test_DefaultNamespace_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.successCases(namespace, experiment, false, *experiment.ID)
 }
 
 func (s *CreateRunTestSuite) Test_DefaultNamespaceExperimentZero_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -64,26 +62,26 @@ func (s *CreateRunTestSuite) Test_DefaultNamespaceExperimentZero_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// update default experiment id for namespace.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.successCases(namespace, experiment, false, int32(0))
 }
 
 func (s *CreateRunTestSuite) Test_CustomNamespace_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -92,21 +90,21 @@ func (s *CreateRunTestSuite) Test_CustomNamespace_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.successCases(namespace, experiment, true, *experiment.ID)
 }
 
 func (s *CreateRunTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -115,19 +113,19 @@ func (s *CreateRunTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// update default experiment id.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.successCases(namespace, experiment, true, int32(0))
 }
@@ -167,22 +165,21 @@ func (s *CreateRunTestSuite) successCases(
 			namespace.Code,
 		)
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		client.DoRequest(
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsCreateRoute,
 		),
 	)
-	assert.NotEmpty(s.T(), resp.Run.Info.ID)
-	assert.NotEmpty(s.T(), resp.Run.Info.UUID)
-	assert.Equal(s.T(), "TestRun", resp.Run.Info.Name)
-	assert.Equal(s.T(), fmt.Sprintf("%d", *experiment.ID), resp.Run.Info.ExperimentID)
-	assert.Equal(s.T(), int64(1234567890), resp.Run.Info.StartTime)
-	assert.Equal(s.T(), int64(0), resp.Run.Info.EndTime)
-	assert.Equal(s.T(), string(models.StatusRunning), resp.Run.Info.Status)
-	assert.NotEmpty(s.T(), resp.Run.Info.ArtifactURI)
-	assert.Equal(s.T(), string(models.LifecycleStageActive), resp.Run.Info.LifecycleStage)
-	assert.Equal(s.T(), []response.RunTagPartialResponse{
+	s.NotEmpty(resp.Run.Info.ID)
+	s.NotEmpty(resp.Run.Info.UUID)
+	s.Equal("TestRun", resp.Run.Info.Name)
+	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.Run.Info.ExperimentID)
+	s.Equal(int64(1234567890), resp.Run.Info.StartTime)
+	s.Equal(int64(0), resp.Run.Info.EndTime)
+	s.Equal(string(models.StatusRunning), resp.Run.Info.Status)
+	s.NotEmpty(resp.Run.Info.ArtifactURI)
+	s.Equal(string(models.LifecycleStageActive), resp.Run.Info.LifecycleStage)
+	s.Equal([]response.RunTagPartialResponse{
 		{
 			Key:   "key1",
 			Value: "value1",
@@ -196,7 +193,7 @@ func (s *CreateRunTestSuite) successCases(
 
 func (s *CreateRunTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -204,19 +201,19 @@ func (s *CreateRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// set namespace default experiment.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name      string
@@ -283,13 +280,12 @@ func (s *CreateRunTestSuite) Test_Error() {
 			).WithResponse(
 				&resp,
 			)
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				client.DoRequest(
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsCreateRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/delete_tag_test.go
+++ b/tests/integration/golang/mlflow/run/delete_tag_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -33,7 +31,7 @@ func TestDeleteRunTagTestSuite(t *testing.T) {
 
 func (s *DeleteRunTagTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -42,14 +40,14 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -69,7 +67,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create few tags,.
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -77,13 +75,13 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "tag2",
 		Value: "value2",
 		RunID: run.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// make actual call to API.
 	query := request.GetRunRequest{
@@ -94,8 +92,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		Key:   "tag1",
 	}
 	resp := fiber.Map{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithQuery(
@@ -108,13 +105,13 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsDeleteTagRoute,
 		),
 	)
-	assert.Equal(s.T(), fiber.Map{}, resp)
+	s.Equal(fiber.Map{}, resp)
 
 	// make sure that we still have one tag connected to Run.
 	tags, err := s.TagFixtures.GetByRunID(context.Background(), run.ID)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), 1, len(tags))
-	assert.Equal(s.T(), []models.Tag{
+	s.Require().Nil(err)
+	s.Equal(1, len(tags))
+	s.Equal([]models.Tag{
 		{
 			Key:   "tag2",
 			RunID: run.ID,
@@ -125,7 +122,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 
 func (s *DeleteRunTagTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -133,7 +130,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test experiment.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
@@ -141,7 +138,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -161,7 +158,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -196,8 +193,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -208,7 +204,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsDeleteTagRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -33,7 +31,7 @@ func TestGetRunTestSuite(t *testing.T) {
 
 func (s *GetRunTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -42,14 +40,14 @@ func (s *GetRunTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -69,7 +67,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create tags, metrics, params.
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
@@ -77,7 +75,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 		Value: "value1",
 		RunID: run.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "metric1",
@@ -87,22 +85,21 @@ func (s *GetRunTestSuite) Test_Ok() {
 		Step:      1,
 		IsNan:     false,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	query := request.GetRunRequest{
 		RunID: run.ID,
 	}
 
 	resp := response.GetRunResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithQuery(
 			query,
 		).WithResponse(
@@ -112,22 +109,22 @@ func (s *GetRunTestSuite) Test_Ok() {
 		),
 	)
 
-	assert.NotEmpty(s.T(), resp.Run.Info.ID)
-	assert.NotEmpty(s.T(), resp.Run.Info.UUID)
-	assert.Equal(s.T(), "TestRun", resp.Run.Info.Name)
-	assert.Equal(s.T(), fmt.Sprintf("%d", *experiment.ID), resp.Run.Info.ExperimentID)
-	assert.Equal(s.T(), int64(1234567890), resp.Run.Info.StartTime)
-	assert.Equal(s.T(), int64(1234567899), resp.Run.Info.EndTime)
-	assert.Equal(s.T(), string(models.StatusRunning), resp.Run.Info.Status)
-	assert.Equal(s.T(), "artifact_uri", resp.Run.Info.ArtifactURI)
-	assert.Equal(s.T(), string(models.LifecycleStageActive), resp.Run.Info.LifecycleStage)
-	assert.Equal(s.T(), []response.RunTagPartialResponse{
+	s.NotEmpty(resp.Run.Info.ID)
+	s.NotEmpty(resp.Run.Info.UUID)
+	s.Equal("TestRun", resp.Run.Info.Name)
+	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.Run.Info.ExperimentID)
+	s.Equal(int64(1234567890), resp.Run.Info.StartTime)
+	s.Equal(int64(1234567899), resp.Run.Info.EndTime)
+	s.Equal(string(models.StatusRunning), resp.Run.Info.Status)
+	s.Equal("artifact_uri", resp.Run.Info.ArtifactURI)
+	s.Equal(string(models.LifecycleStageActive), resp.Run.Info.LifecycleStage)
+	s.Equal([]response.RunTagPartialResponse{
 		{
 			Key:   "tag1",
 			Value: "value1",
 		},
 	}, resp.Run.Data.Tags)
-	assert.Equal(s.T(), []response.RunMetricPartialResponse{
+	s.Equal([]response.RunMetricPartialResponse{
 		{
 			Key:       "metric1",
 			Step:      1,
@@ -135,7 +132,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 			Timestamp: 1234567890,
 		},
 	}, resp.Run.Data.Metrics)
-	assert.Equal(s.T(), []response.RunParamPartialResponse{
+	s.Equal([]response.RunParamPartialResponse{
 		{
 			Key:   "param1",
 			Value: "value1",
@@ -145,7 +142,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 
 func (s *GetRunTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -153,7 +150,7 @@ func (s *GetRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -178,8 +175,7 @@ func (s *GetRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithQuery(
 					tt.request,
 				).WithResponse(
@@ -188,8 +184,8 @@ func (s *GetRunTestSuite) Test_Error() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsGetRoute,
 				),
 			)
-			require.Nil(s.T(), err)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Require().Nil(err)
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestLogBatchTestSuite(t *testing.T) {
 
 func (s *LogBatchTestSuite) TestTags_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,14 +38,14 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -56,7 +54,7 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -78,8 +76,7 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := map[string]any{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -90,14 +87,14 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogBatchRoute,
 				),
 			)
-			assert.Empty(s.T(), resp)
+			s.Empty(resp)
 		})
 	}
 }
 
 func (s *LogBatchTestSuite) TestParams_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -105,14 +102,14 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -121,7 +118,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create preexisting param (other batch) for conflict testing
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
@@ -129,7 +126,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 		Key:   "key1",
 		Value: "value1",
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -179,8 +176,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := map[string]any{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -191,13 +187,13 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogBatchRoute,
 				),
 			)
-			assert.Empty(s.T(), resp)
+			s.Empty(resp)
 
 			// verify params are inserted
 			params, err := s.ParamFixtures.GetParamsByRunID(context.Background(), run.ID)
-			require.Nil(s.T(), err)
+			s.Require().Nil(err)
 			for _, param := range tt.request.Params {
-				assert.Contains(s.T(), params, models.Param{Key: param.Key, Value: param.Value, RunID: run.ID})
+				s.Contains(params, models.Param{Key: param.Key, Value: param.Value, RunID: run.ID})
 			}
 		})
 	}
@@ -205,7 +201,7 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 
 func (s *LogBatchTestSuite) TestMetrics_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -213,14 +209,14 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -229,7 +225,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name                  string
@@ -358,8 +354,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 		s.Run(tt.name, func() {
 			// do actual call to API.
 			resp := map[string]any{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -370,13 +365,13 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogBatchRoute,
 				),
 			)
-			assert.Empty(s.T(), resp)
+			s.Empty(resp)
 
 			// make sure that `iter` and `last_iter` for each metric has been updated correctly.
 			for key, iteration := range tt.latestMetricIteration {
 				lastMetric, err := s.MetricFixtures.GetLatestMetricByKey(context.Background(), key)
-				require.Nil(s.T(), err)
-				assert.Equal(s.T(), iteration, lastMetric.LastIter)
+				s.Require().Nil(err)
+				s.Equal(iteration, lastMetric.LastIter)
 			}
 		})
 	}
@@ -384,7 +379,7 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 
 func (s *LogBatchTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -392,14 +387,14 @@ func (s *LogBatchTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -408,7 +403,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	testData := []struct {
 		name    string
@@ -446,8 +441,7 @@ func (s *LogBatchTestSuite) Test_Error() {
 	for _, tt := range testData {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -458,13 +452,13 @@ func (s *LogBatchTestSuite) Test_Error() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogBatchRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.ErrorCode, resp.ErrorCode)
-			assert.Contains(s.T(), resp.Error(), tt.error.Message)
+			s.Equal(tt.error.ErrorCode, resp.ErrorCode)
+			s.Contains(resp.Error(), tt.error.Message)
 
 			// there should be no params inserted when error occurs.
 			params, err := s.ParamFixtures.GetParamsByRunID(context.Background(), run.ID)
-			require.Nil(s.T(), err)
-			assert.Empty(s.T(), params)
+			s.Require().Nil(err)
+			s.Empty(params)
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestLogMetricTestSuite(t *testing.T) {
 
 func (s *LogMetricTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +38,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment := &models.Experiment{
 		Name:           uuid.New().String(),
@@ -48,7 +46,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 	}
 	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run := &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -58,7 +56,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		Status:         models.StatusRunning,
 	}
 	run, err = s.RunFixtures.CreateRun(context.Background(), run)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.LogMetricRequest{
 		RunID:     run.ID,
@@ -68,8 +66,7 @@ func (s *LogMetricTestSuite) Test_Ok() {
 		Step:      1,
 	}
 	resp := fiber.Map{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -80,12 +77,12 @@ func (s *LogMetricTestSuite) Test_Ok() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogMetricRoute,
 		),
 	)
-	assert.Empty(s.T(), resp)
+	s.Empty(resp)
 
 	// makes user that records has been created correctly in database.
 	metric, err := s.MetricFixtures.GetLatestMetricByRunID(context.Background(), run.ID)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), &models.LatestMetric{
+	s.Require().Nil(err)
+	s.Equal(&models.LatestMetric{
 		Key:       "key1",
 		Value:     1.1,
 		Timestamp: 1234567890,
@@ -114,11 +111,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 				return ""
 			},
 			cleanDatabase: func() {
-				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 		{
@@ -133,11 +130,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 				return ""
 			},
 			cleanDatabase: func() {
-				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 		{
@@ -154,11 +151,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 				return ""
 			},
 			cleanDatabase: func() {
-				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 		{
@@ -175,7 +172,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Code:                "default",
 					DefaultExperimentID: common.GetPointer(int32(0)),
 				})
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 
 				experiment := &models.Experiment{
 					Name:           uuid.New().String(),
@@ -183,7 +180,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 					LifecycleStage: models.LifecycleStageActive,
 				}
 				_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 
 				run := &models.Run{
 					ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -193,11 +190,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 					Status:         models.StatusRunning,
 				}
 				run, err = s.RunFixtures.CreateRun(context.Background(), run)
-				require.Nil(s.T(), err)
+				s.Require().Nil(err)
 				return run.ID
 			},
 			cleanDatabase: func() {
-				require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 	}
@@ -211,8 +208,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 			}
 
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -223,7 +219,7 @@ func (s *LogMetricTestSuite) Test_Error() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogMetricRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 
 			// if cleanDatabase has been provided then clean database after the test.
 			if tt.cleanDatabase != nil {

--- a/tests/integration/golang/mlflow/run/log_parameter_test.go
+++ b/tests/integration/golang/mlflow/run/log_parameter_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -32,7 +30,7 @@ func TestLogParamTestSuite(t *testing.T) {
 
 func (s *LogParamTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -40,7 +38,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment := &models.Experiment{
 		Name:           uuid.New().String(),
@@ -48,7 +46,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		LifecycleStage: models.LifecycleStageActive,
 	}
 	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run := &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -58,7 +56,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Status:         models.StatusRunning,
 	}
 	run, err = s.RunFixtures.CreateRun(context.Background(), run)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.LogParamRequest{
 		RunID: run.ID,
@@ -66,8 +64,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Value: "value1",
 	}
 	resp := map[string]any{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -78,7 +75,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogParameterRoute,
 		),
 	)
-	assert.Empty(s.T(), resp)
+	s.Empty(resp)
 
 	// log duplicate, which is OK
 	req = request.LogParamRequest{
@@ -86,8 +83,7 @@ func (s *LogParamTestSuite) Test_Ok() {
 		Key:   "key1",
 		Value: "value1",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -98,12 +94,12 @@ func (s *LogParamTestSuite) Test_Ok() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogParameterRoute,
 		),
 	)
-	assert.Empty(s.T(), resp)
+	s.Empty(resp)
 }
 
 func (s *LogParamTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -111,7 +107,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment := &models.Experiment{
 		Name:           uuid.New().String(),
@@ -119,7 +115,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		LifecycleStage: models.LifecycleStageActive,
 	}
 	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run := &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
@@ -129,7 +125,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Status:         models.StatusRunning,
 	}
 	run, err = s.RunFixtures.CreateRun(context.Background(), run)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// setup param OK
 	req := request.LogParamRequest{
@@ -138,8 +134,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Value: "value1",
 	}
 	resp := api.ErrorResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -150,7 +145,7 @@ func (s *LogParamTestSuite) Test_Error() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogParameterRoute,
 		),
 	)
-	assert.Empty(s.T(), resp)
+	s.Empty(resp)
 
 	// error conditions
 
@@ -159,8 +154,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Key:   "key1",
 		Value: "value1",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -171,8 +165,7 @@ func (s *LogParamTestSuite) Test_Error() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogParameterRoute,
 		),
 	)
-	assert.Equal(
-		s.T(),
+	s.Equal(
 		api.NewInvalidParameterValueError("Missing value for required parameter 'run_id'").Error(),
 		resp.Error(),
 	)
@@ -183,8 +176,7 @@ func (s *LogParamTestSuite) Test_Error() {
 		Key:   "key1",
 		Value: "value2",
 	}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -195,8 +187,7 @@ func (s *LogParamTestSuite) Test_Error() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsLogParameterRoute,
 		),
 	)
-	assert.Equal(
-		s.T(),
+	s.Equal(
 		api.NewInvalidParameterValueError(
 			fmt.Sprintf(`unable to insert params for run '%s': conflicting params found: `+
 				`[{run_id: %s, key: %s, old_value: %s, new_value: %s}]`,

--- a/tests/integration/golang/mlflow/run/search_test.go
+++ b/tests/integration/golang/mlflow/run/search_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -34,7 +32,7 @@ func TestSearchTestSuite(t *testing.T) {
 
 func (s *SearchTestSuite) Test_DefaultNamespace_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create default namespace and experiment.
@@ -43,21 +41,21 @@ func (s *SearchTestSuite) Test_DefaultNamespace_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.testCases(namespace, experiment, false, *experiment.ID)
 }
 
 func (s *SearchTestSuite) Test_DefaultNamespaceExerimentZero_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create default namespace and experiment.
@@ -66,26 +64,26 @@ func (s *SearchTestSuite) Test_DefaultNamespaceExerimentZero_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// update default experiment id.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.testCases(namespace, experiment, false, int32(0))
 }
 
 func (s *SearchTestSuite) Test_CustomNamespace_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create custom namespace and experiment.
@@ -93,21 +91,21 @@ func (s *SearchTestSuite) Test_CustomNamespace_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.testCases(namespace, experiment, true, *experiment.ID)
 }
 
 func (s *SearchTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create custom namespace and experiment.
@@ -115,19 +113,19 @@ func (s *SearchTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// update default experiment id.
 	namespace.DefaultExperimentID = experiment.ID
 	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	s.testCases(namespace, experiment, true, int32(0))
 }
@@ -157,13 +155,13 @@ func (s *SearchTestSuite) testCases(
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag1",
 		RunID: run1.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "run1",
 		Value:     1.1,
@@ -173,13 +171,13 @@ func (s *SearchTestSuite) testCases(
 		RunID:     run1.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param1",
 		Value: "value1",
 		RunID: run1.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run2, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id2",
@@ -199,13 +197,13 @@ func (s *SearchTestSuite) testCases(
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag2",
 		RunID: run2.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "run2",
 		Value:     2.1,
@@ -215,13 +213,13 @@ func (s *SearchTestSuite) testCases(
 		RunID:     run2.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param2",
 		Value: "value2",
 		RunID: run2.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	run3, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:         "id3",
@@ -241,13 +239,13 @@ func (s *SearchTestSuite) testCases(
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
 		Value: "TestRunTag3",
 		RunID: run3.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.MetricFixtures.CreateLatestMetric(context.Background(), &models.LatestMetric{
 		Key:       "run3",
 		Value:     3.1,
@@ -257,13 +255,13 @@ func (s *SearchTestSuite) testCases(
 		RunID:     run3.ID,
 		LastIter:  1,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 	_, err = s.ParamFixtures.CreateParam(context.Background(), &models.Param{
 		Key:   "param3",
 		Value: "value3",
 		RunID: run3.ID,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name     string
@@ -2958,14 +2956,13 @@ func (s *SearchTestSuite) testCases(
 					namespace.Code,
 				)
 			}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				client.DoRequest(
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsSearchRoute,
 				),
 			)
-			assert.Equal(s.T(), len(tt.response.Runs), len(resp.Runs))
-			assert.Equal(s.T(), len(tt.response.NextPageToken), len(resp.NextPageToken))
+			s.Equal(len(tt.response.Runs), len(resp.Runs))
+			s.Equal(len(tt.response.NextPageToken), len(resp.NextPageToken))
 
 			mappedExpectedResult := make(map[string]*response.RunPartialResponse, len(tt.response.Runs))
 			for _, run := range tt.response.Runs {
@@ -2975,20 +2972,20 @@ func (s *SearchTestSuite) testCases(
 			if tt.response.Runs != nil && resp.Runs != nil {
 				for _, actualRun := range resp.Runs {
 					expectedRun, ok := mappedExpectedResult[actualRun.Info.ID]
-					assert.True(s.T(), ok)
-					assert.NotEmpty(s.T(), actualRun.Info.ID)
-					assert.Equal(s.T(), expectedRun.Info.Name, actualRun.Info.Name)
-					assert.Equal(s.T(), expectedRun.Info.Name, actualRun.Info.Name)
-					assert.Equal(s.T(), expectedRun.Info.UserID, actualRun.Info.UserID)
-					assert.Equal(s.T(), expectedRun.Info.Status, actualRun.Info.Status)
-					assert.Equal(s.T(), expectedRun.Info.EndTime, actualRun.Info.EndTime)
-					assert.Equal(s.T(), expectedRun.Info.StartTime, actualRun.Info.StartTime)
-					assert.Equal(s.T(), expectedRun.Info.ArtifactURI, actualRun.Info.ArtifactURI)
-					assert.Equal(s.T(), expectedRun.Info.ExperimentID, actualRun.Info.ExperimentID)
-					assert.Equal(s.T(), expectedRun.Info.LifecycleStage, actualRun.Info.LifecycleStage)
-					assert.Equal(s.T(), expectedRun.Data.Tags, actualRun.Data.Tags)
-					assert.Equal(s.T(), expectedRun.Data.Params, actualRun.Data.Params)
-					assert.Equal(s.T(), expectedRun.Data.Metrics, actualRun.Data.Metrics)
+					s.True(ok)
+					s.NotEmpty(actualRun.Info.ID)
+					s.Equal(expectedRun.Info.Name, actualRun.Info.Name)
+					s.Equal(expectedRun.Info.Name, actualRun.Info.Name)
+					s.Equal(expectedRun.Info.UserID, actualRun.Info.UserID)
+					s.Equal(expectedRun.Info.Status, actualRun.Info.Status)
+					s.Equal(expectedRun.Info.EndTime, actualRun.Info.EndTime)
+					s.Equal(expectedRun.Info.StartTime, actualRun.Info.StartTime)
+					s.Equal(expectedRun.Info.ArtifactURI, actualRun.Info.ArtifactURI)
+					s.Equal(expectedRun.Info.ExperimentID, actualRun.Info.ExperimentID)
+					s.Equal(expectedRun.Info.LifecycleStage, actualRun.Info.LifecycleStage)
+					s.Equal(expectedRun.Data.Tags, actualRun.Data.Tags)
+					s.Equal(expectedRun.Data.Params, actualRun.Data.Params)
+					s.Equal(expectedRun.Data.Metrics, actualRun.Data.Metrics)
 				}
 			}
 		})

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -33,7 +31,7 @@ func TestSetRunTagTestSuite(t *testing.T) {
 
 func (s *SetRunTagTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -42,14 +40,14 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -69,7 +67,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.SetRunTagRequest{
 		RunID: run.ID,
@@ -77,8 +75,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		Value: "value1",
 	}
 	resp := fiber.Map{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -89,13 +86,13 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsSetTagRoute,
 		),
 	)
-	assert.Equal(s.T(), fiber.Map{}, resp)
+	s.Equal(fiber.Map{}, resp)
 
 	// make sure that new tag has been created.
 	tags, err := s.TagFixtures.GetByRunID(context.Background(), run.ID)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), 1, len(tags))
-	assert.Equal(s.T(), []models.Tag{
+	s.Require().Nil(err)
+	s.Equal(1, len(tags))
+	s.Equal([]models.Tag{
 		{
 			RunID: run.ID,
 			Key:   "tag1",
@@ -106,7 +103,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 
 func (s *SetRunTagTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -114,7 +111,7 @@ func (s *SetRunTagTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -147,8 +144,7 @@ func (s *SetRunTagTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -159,7 +155,7 @@ func (s *SetRunTagTestSuite) Test_Error() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsSetTagRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/update_test.go
+++ b/tests/integration/golang/mlflow/run/update_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
@@ -34,7 +32,7 @@ func TestUpdateRunTestSuite(t *testing.T) {
 
 func (s *UpdateRunTestSuite) Test_Ok() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	// create test experiment.
@@ -43,14 +41,14 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		NamespaceID:    namespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	// create test run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
@@ -70,7 +68,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		ExperimentID:   *experiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	req := request.UpdateRunRequest{
 		RunID:   run.ID,
@@ -79,8 +77,7 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 		EndTime: 1111111111,
 	}
 	resp := response.UpdateRunResponse{}
-	require.Nil(
-		s.T(),
+	s.Require().Nil(
 		s.MlflowClient().WithMethod(
 			http.MethodPost,
 		).WithRequest(
@@ -91,27 +88,27 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 			"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsUpdateRoute,
 		),
 	)
-	assert.NotEmpty(s.T(), resp.RunInfo.ID)
-	assert.NotEmpty(s.T(), resp.RunInfo.UUID)
-	assert.Equal(s.T(), "UpdatedName", resp.RunInfo.Name)
-	assert.Equal(s.T(), fmt.Sprintf("%d", *experiment.ID), resp.RunInfo.ExperimentID)
-	assert.Equal(s.T(), int64(1234567890), resp.RunInfo.StartTime)
-	assert.Equal(s.T(), int64(1111111111), resp.RunInfo.EndTime)
-	assert.Equal(s.T(), string(models.StatusScheduled), resp.RunInfo.Status)
-	assert.NotEmpty(s.T(), resp.RunInfo.ArtifactURI)
-	assert.Equal(s.T(), string(models.LifecycleStageActive), resp.RunInfo.LifecycleStage)
+	s.NotEmpty(resp.RunInfo.ID)
+	s.NotEmpty(resp.RunInfo.UUID)
+	s.Equal("UpdatedName", resp.RunInfo.Name)
+	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.RunInfo.ExperimentID)
+	s.Equal(int64(1234567890), resp.RunInfo.StartTime)
+	s.Equal(int64(1111111111), resp.RunInfo.EndTime)
+	s.Equal(string(models.StatusScheduled), resp.RunInfo.Status)
+	s.NotEmpty(resp.RunInfo.ArtifactURI)
+	s.Equal(string(models.LifecycleStageActive), resp.RunInfo.LifecycleStage)
 
 	// check that run has been updated in database.
 	run, err = s.RunFixtures.GetRun(context.Background(), run.ID)
-	require.Nil(s.T(), err)
-	assert.Equal(s.T(), "UpdatedName", run.Name)
-	assert.Equal(s.T(), models.StatusScheduled, run.Status)
-	assert.Equal(s.T(), int64(1111111111), run.EndTime.Int64)
+	s.Require().Nil(err)
+	s.Equal("UpdatedName", run.Name)
+	s.Equal(models.StatusScheduled, run.Status)
+	s.Equal(int64(1111111111), run.EndTime.Int64)
 }
 
 func (s *UpdateRunTestSuite) Test_Error() {
 	defer func() {
-		require.Nil(s.T(), s.NamespaceFixtures.UnloadFixtures())
+		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	}()
 
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
@@ -119,7 +116,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 		Code:                "default",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
-	require.Nil(s.T(), err)
+	s.Require().Nil(err)
 
 	tests := []struct {
 		name    string
@@ -142,8 +139,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			resp := api.ErrorResponse{}
-			require.Nil(
-				s.T(),
+			s.Require().Nil(
 				s.MlflowClient().WithMethod(
 					http.MethodPost,
 				).WithRequest(
@@ -154,7 +150,7 @@ func (s *UpdateRunTestSuite) Test_Error() {
 					"%s%s", mlflow.RunsRoutePrefix, mlflow.RunsUpdateRoute,
 				),
 			)
-			assert.Equal(s.T(), tt.error.Error(), resp.Error())
+			s.Equal(tt.error.Error(), resp.Error())
 		})
 	}
 }


### PR DESCRIPTION
This PR changes the way we use `assert` and `require` to the more idiomatic way of using the test suite directly.

For example, this
```go
assert.Equal(s.T(), expected, actual)
```

becomes
```go
s.Equal(expected, actual)
```