### PR TITLE
Refactor test suite setup/teardown

### DIFF
--- a/tests/integration/golang/admin/namespace/create_test.go
+++ b/tests/integration/golang/admin/namespace/create_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/ui/admin/request"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -25,16 +23,6 @@ func TestCreateNamespaceTestSuite(t *testing.T) {
 }
 
 func (s *CreateNamespaceTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	requests := []request.Namespace{
 		{
 			Code:        "test2",
@@ -64,16 +52,6 @@ func (s *CreateNamespaceTestSuite) Test_Ok() {
 }
 
 func (s *CreateNamespaceTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		request *request.Namespace

--- a/tests/integration/golang/admin/namespace/delete_test.go
+++ b/tests/integration/golang/admin/namespace/delete_test.go
@@ -23,16 +23,7 @@ func TestDeleteNamespaceTestSuite(t *testing.T) {
 }
 
 func (s *DeleteNamespaceTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",
@@ -73,16 +64,7 @@ func (s *DeleteNamespaceTestSuite) Test_Ok() {
 }
 
 func (s *DeleteNamespaceTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",

--- a/tests/integration/golang/admin/namespace/update_test.go
+++ b/tests/integration/golang/admin/namespace/update_test.go
@@ -24,15 +24,6 @@ func TestUpdateNamespaceTestSuite(t *testing.T) {
 }
 
 func (s *UpdateNamespaceTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
 	ns, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
@@ -61,16 +52,7 @@ func (s *UpdateNamespaceTestSuite) Test_Ok() {
 }
 
 func (s *UpdateNamespaceTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-	_, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		ID:                  2,
 		Code:                "test2",
 		Description:         "test namespace 2 description",

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -3,7 +3,6 @@
 package run
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -11,8 +10,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
@@ -25,17 +22,6 @@ func TestCreateAppTestSuite(t *testing.T) {
 }
 
 func (s *CreateAppTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name        string
 		requestBody request.CreateApp
@@ -74,17 +60,6 @@ func (s *CreateAppTestSuite) Test_Ok() {
 }
 
 func (s *CreateAppTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name        string
 		requestBody any

--- a/tests/integration/golang/aim/app/delete_app_test.go
+++ b/tests/integration/golang/aim/app/delete_app_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -27,17 +25,6 @@ func TestDeleteAppTestSuite(t *testing.T) {
 }
 
 func (s *DeleteAppTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:        uuid.New(),
@@ -45,7 +32,7 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -75,25 +62,14 @@ func (s *DeleteAppTestSuite) Test_Ok() {
 }
 
 func (s *DeleteAppTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	_, err = s.AppFixtures.CreateApp(context.Background(), &database.App{
+	_, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:        uuid.New(),
 			CreatedAt: time.Now(),
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/app/get_app_test.go
+++ b/tests/integration/golang/aim/app/get_app_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -26,17 +24,6 @@ func TestGetAppTestSuite(t *testing.T) {
 }
 
 func (s *GetAppTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:        uuid.New(),
@@ -44,7 +31,7 @@ func (s *GetAppTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -58,17 +45,6 @@ func (s *GetAppTestSuite) Test_Ok() {
 }
 
 func (s *GetAppTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		idParam uuid.UUID

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -20,7 +18,11 @@ type GetAppsTestSuite struct {
 }
 
 func TestGetAppsTestSuite(t *testing.T) {
-	suite.Run(t, new(GetAppsTestSuite))
+	suite.Run(t, &GetAppsTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest: true,
+		},
+	})
 }
 
 func (s *GetAppsTestSuite) Test_Ok() {
@@ -39,18 +41,7 @@ func (s *GetAppsTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer func() {
-				s.Require().Nil(s.AppFixtures.UnloadFixtures())
-			}()
-
-			namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-				ID:                  1,
-				Code:                "default",
-				DefaultExperimentID: common.GetPointer(int32(0)),
-			})
-			s.Require().Nil(err)
-
-			apps, err := s.AppFixtures.CreateApps(context.Background(), namespace, tt.expectedAppCount)
+			apps, err := s.AppFixtures.CreateApps(context.Background(), s.DefaultNamespace, tt.expectedAppCount)
 			s.Require().Nil(err)
 
 			var resp []response.App

--- a/tests/integration/golang/aim/app/update_app_test.go
+++ b/tests/integration/golang/aim/app/update_app_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,17 +26,6 @@ func TestUpdateAppTestSuite(t *testing.T) {
 }
 
 func (s *UpdateAppTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:        uuid.New(),
@@ -46,7 +33,7 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -96,17 +83,6 @@ func (s *UpdateAppTestSuite) Test_Ok() {
 }
 
 func (s *UpdateAppTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:        uuid.New(),
@@ -114,7 +90,7 @@ func (s *UpdateAppTestSuite) Test_Error() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,17 +26,6 @@ func TestCreateDashboardTestSuite(t *testing.T) {
 }
 
 func (s *CreateDashboardTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:         uuid.New(),
@@ -47,7 +34,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -91,17 +78,6 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 }
 
 func (s *CreateDashboardTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name        string
 		requestBody request.CreateDashboard

--- a/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -27,17 +25,6 @@ func TestDeleteDashboardTestSuite(t *testing.T) {
 }
 
 func (s *DeleteDashboardTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:         uuid.New(),
@@ -46,7 +33,7 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -91,17 +78,6 @@ func (s *DeleteDashboardTestSuite) Test_Ok() {
 }
 
 func (s *DeleteDashboardTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:         uuid.New(),
@@ -110,7 +86,7 @@ func (s *DeleteDashboardTestSuite) Test_Error() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -26,17 +24,6 @@ func TestGetDashboardTestSuite(t *testing.T) {
 }
 
 func (s *GetDashboardTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:         uuid.New(),
@@ -45,7 +32,7 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -72,17 +59,6 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 }
 
 func (s *GetDashboardTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		idParam string

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -22,7 +20,11 @@ type GetDashboardsTestSuite struct {
 }
 
 func TestGetDashboardsTestSuite(t *testing.T) {
-	suite.Run(t, new(GetDashboardsTestSuite))
+	suite.Run(t, &GetDashboardsTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest: true,
+		},
+	})
 }
 
 func (s *GetDashboardsTestSuite) Test_Ok() {
@@ -41,17 +43,6 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer func() {
-				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-			}()
-
-			namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-				ID:                  1,
-				Code:                "default",
-				DefaultExperimentID: common.GetPointer(int32(0)),
-			})
-			s.Require().Nil(err)
-
 			app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 				Base: database.Base{
 					ID:         uuid.New(),
@@ -60,7 +51,7 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 				},
 				Type:        "mpi",
 				State:       database.AppState{},
-				NamespaceID: namespace.ID,
+				NamespaceID: s.DefaultNamespace.ID,
 			})
 			s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,17 +26,6 @@ func TestUpdateDashboardTestSuite(t *testing.T) {
 }
 
 func (s *UpdateDashboardTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:         uuid.New(),
@@ -47,7 +34,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
@@ -114,17 +101,6 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 }
 
 func (s *UpdateDashboardTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	app, err := s.AppFixtures.CreateApp(context.Background(), &database.App{
 		Base: database.Base{
 			ID:         uuid.New(),
@@ -133,7 +109,7 @@ func (s *UpdateDashboardTestSuite) Test_Error() {
 		},
 		Type:        "mpi",
 		State:       database.AppState{},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -21,24 +20,17 @@ type DeleteExperimentTestSuite struct {
 }
 
 func TestDeleteExperimentTestSuite(t *testing.T) {
-	suite.Run(t, new(DeleteExperimentTestSuite))
+	suite.Run(t, &DeleteExperimentTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *DeleteExperimentTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           "Test Experiment",
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -64,17 +56,6 @@ func (s *DeleteExperimentTestSuite) Test_Ok() {
 }
 
 func (s *DeleteExperimentTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name  string
 		ID    string
@@ -105,7 +86,6 @@ func (s *DeleteExperimentTestSuite) Test_Error() {
 				),
 			)
 			s.Contains(resp.Error(), tt.error)
-			s.NoError(err)
 		})
 	}
 }

--- a/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -21,24 +20,17 @@ type GetExperimentActivityTestSuite struct {
 }
 
 func TestGetExperimentActivityTestSuite(t *testing.T) {
-	suite.Run(t, new(GetExperimentActivityTestSuite))
+	suite.Run(t, &GetExperimentActivityTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *GetExperimentActivityTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -47,7 +39,7 @@ func (s *GetExperimentActivityTestSuite) Test_Ok() {
 	s.Require().Nil(err)
 
 	archivedRunsIds := []string{runs[0].ID, runs[1].ID}
-	err = s.RunFixtures.ArchiveRuns(context.Background(), namespace.ID, archivedRunsIds)
+	err = s.RunFixtures.ArchiveRuns(context.Background(), s.DefaultNamespace.ID, archivedRunsIds)
 	s.Require().Nil(err)
 
 	var resp response.GetExperimentActivity
@@ -61,17 +53,6 @@ func (s *GetExperimentActivityTestSuite) Test_Ok() {
 }
 
 func (s *GetExperimentActivityTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name  string
 		ID    string

--- a/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -21,24 +20,17 @@ type GetExperimentRunsTestSuite struct {
 }
 
 func TestGetExperimentRunsTestSuite(t *testing.T) {
-	suite.Run(t, new(GetExperimentRunsTestSuite))
+	suite.Run(t, &GetExperimentRunsTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *GetExperimentRunsTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -68,17 +60,6 @@ func (s *GetExperimentRunsTestSuite) Test_Ok() {
 }
 
 func (s *GetExperimentRunsTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name  string
 		error string

--- a/tests/integration/golang/aim/experiment/get_experiment_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_test.go
@@ -23,21 +23,14 @@ type GetExperimentTestSuite struct {
 }
 
 func TestGetExperimentTestSuite(t *testing.T) {
-	suite.Run(t, new(GetExperimentTestSuite))
+	suite.Run(t, &GetExperimentTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *GetExperimentTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
 		Tags: []models.ExperimentTag{
@@ -50,7 +43,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 			Int64: time.Now().UTC().UnixMilli(),
 			Valid: true,
 		},
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -66,17 +59,6 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 }
 
 func (s *GetExperimentTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name  string
 		error string

--- a/tests/integration/golang/aim/experiment/get_experiments_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiments_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -22,26 +21,19 @@ type GetExperimentsTestSuite struct {
 }
 
 func TestGetExperimentsTestSuite(t *testing.T) {
-	suite.Run(t, new(GetExperimentsTestSuite))
+	suite.Run(t, &GetExperimentsTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *GetExperimentsTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiments := map[string]*models.Experiment{}
 	for i := 0; i < 5; i++ {
 		experiment := &models.Experiment{
 			Name:        fmt.Sprintf("Test Experiment %d", i),
-			NamespaceID: namespace.ID,
+			NamespaceID: s.DefaultNamespace.ID,
 			CreationTime: sql.NullInt64{
 				Int64: time.Now().UTC().UnixMilli(),
 				Valid: true,

--- a/tests/integration/golang/aim/metric/search_aligned_test.go
+++ b/tests/integration/golang/aim/metric/search_aligned_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,28 +28,18 @@ func TestSearchAlignedMetricsTestSuite(t *testing.T) {
 }
 
 func (s *SearchAlignedMetricsTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/metric/search_test.go
+++ b/tests/integration/golang/aim/metric/search_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,29 +27,18 @@ func TestSearchMetricsTestSuite(t *testing.T) {
 }
 
 func (s *SearchMetricsTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
 	experiment1, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/namespace/flows/app_test.go
+++ b/tests/integration/golang/aim/namespace/flows/app_test.go
@@ -23,11 +23,12 @@ type AppFlowTestSuite struct {
 }
 
 func TestAppFlowTestSuite(t *testing.T) {
-	suite.Run(t, &AppFlowTestSuite{})
-}
-
-func (s *AppFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &AppFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *AppFlowTestSuite) Test_Ok() {
@@ -55,10 +56,6 @@ func (s *AppFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer func() {
-				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-			}()
-
 			// setup namespaces
 			for _, nsCode := range []string{"default", tt.namespace1Code, tt.namespace2Code} {
 				_, err := s.NamespaceFixtures.UpsertNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/aim/namespace/flows/dashboard_test.go
+++ b/tests/integration/golang/aim/namespace/flows/dashboard_test.go
@@ -24,11 +24,12 @@ type DashboardFlowTestSuite struct {
 }
 
 func TestDashboardFlowTestSuite(t *testing.T) {
-	suite.Run(t, &DashboardFlowTestSuite{})
-}
-
-func (s *DashboardFlowTestSuite) TearDownTest() {
-	s.Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &DashboardFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *DashboardFlowTestSuite) Test_Ok() {
@@ -56,10 +57,6 @@ func (s *DashboardFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer func() {
-				s.Nil(s.NamespaceFixtures.UnloadFixtures())
-			}()
-
 			// setup namespaces
 			for _, nsCode := range []string{"default", tt.namespace1Code, tt.namespace2Code} {
 				_, err := s.NamespaceFixtures.UpsertNamespace(context.Background(), &models.Namespace{

--- a/tests/integration/golang/aim/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/aim/namespace/flows/experiment_test.go
@@ -27,11 +27,12 @@ type ExperimentFlowTestSuite struct {
 // - `GET /experiments/:id/runs`
 // - `GET /experiments/:id/activity`
 func TestExperimentFlowTestSuite(t *testing.T) {
-	suite.Run(t, new(ExperimentFlowTestSuite))
-}
-
-func (s *ExperimentFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &ExperimentFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *ExperimentFlowTestSuite) Test_Ok() {
@@ -87,8 +88,6 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/aim/namespace/flows/metric_test.go
+++ b/tests/integration/golang/aim/namespace/flows/metric_test.go
@@ -28,11 +28,12 @@ type MetricFlowTestSuite struct {
 // - `GET /runs/search/metric`
 // - `GET /runs/search/metric/align`
 func TestMetricTestSuite(t *testing.T) {
-	suite.Run(t, new(MetricFlowTestSuite))
-}
-
-func (s *MetricFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &MetricFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *MetricFlowTestSuite) Test_Ok() {
@@ -88,8 +89,6 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/aim/namespace/flows/project_test.go
+++ b/tests/integration/golang/aim/namespace/flows/project_test.go
@@ -25,11 +25,12 @@ type ProjectFlowTestSuite struct {
 // - `GET /projects/params`
 // - `GET /projects/activity`
 func TestProjectFlowTestSuite(t *testing.T) {
-	suite.Run(t, new(ProjectFlowTestSuite))
-}
-
-func (s *ProjectFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &ProjectFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *ProjectFlowTestSuite) Test_Ok() {
@@ -85,8 +86,6 @@ func (s *ProjectFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/aim/namespace/flows/run_test.go
+++ b/tests/integration/golang/aim/namespace/flows/run_test.go
@@ -35,11 +35,12 @@ type RunFlowTestSuite struct {
 // - `DELETE /runs/:id`
 // - `DELETE /runs/delete-batch`
 func TestRunFlowTestSuite(t *testing.T) {
-	suite.Run(t, new(RunFlowTestSuite))
-}
-
-func (s *RunFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &RunFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *RunFlowTestSuite) Test_Ok() {
@@ -95,8 +96,6 @@ func (s *RunFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/aim/namespace/namespace_test.go
+++ b/tests/integration/golang/aim/namespace/namespace_test.go
@@ -16,11 +16,11 @@ type NamespaceTestSuite struct {
 }
 
 func TestNamespaceTestSuite(t *testing.T) {
-	suite.Run(t, new(NamespaceTestSuite))
-}
-
-func (s *NamespaceTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &NamespaceTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *NamespaceTestSuite) Test_Error() {

--- a/tests/integration/golang/aim/project/get_project_activity_test.go
+++ b/tests/integration/golang/aim/project/get_project_activity_test.go
@@ -6,12 +6,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
@@ -24,29 +21,11 @@ func TestGetProjectActivityTestSuite(t *testing.T) {
 }
 
 func (s *GetProjectActivityTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
+	runs, err := s.RunFixtures.CreateExampleRuns(context.Background(), s.DefaultExperiment, 10)
 	s.Require().Nil(err)
 
 	archivedRunsIds := []string{runs[0].ID, runs[1].ID}
-	err = s.RunFixtures.ArchiveRuns(context.Background(), namespace.ID, archivedRunsIds)
+	err = s.RunFixtures.ArchiveRuns(context.Background(), s.DefaultNamespace.ID, archivedRunsIds)
 	s.Require().Nil(err)
 
 	var resp response.ProjectActivityResponse

--- a/tests/integration/golang/aim/project/get_project_status_test.go
+++ b/tests/integration/golang/aim/project/get_project_status_test.go
@@ -3,13 +3,10 @@
 package run
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
@@ -22,17 +19,6 @@ func TestGetProjectStatusTestSuite(t *testing.T) {
 }
 
 func (s *GetProjectStatusTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	var resp string
 	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/projects/status"))
 	s.Equal("up-to-date", resp)

--- a/tests/integration/golang/aim/project/get_project_test.go
+++ b/tests/integration/golang/aim/project/get_project_test.go
@@ -3,14 +3,11 @@
 package run
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
@@ -23,17 +20,6 @@ func TestGetProjectTestSuite(t *testing.T) {
 }
 
 func (s *GetProjectTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	var resp response.GetProjectResponse
 	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/projects"))
 	s.Equal("FastTrackML", resp.Name)

--- a/tests/integration/golang/aim/run/archive_batch_test.go
+++ b/tests/integration/golang/aim/run/archive_batch_test.go
@@ -8,10 +8,8 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,29 +26,12 @@ func TestArchiveBatchTestSuite(t *testing.T) {
 func (s *ArchiveBatchTestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
+	var err error
+	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), s.DefaultExperiment, 10)
 	s.Require().Nil(err)
 }
 
 func (s *ArchiveBatchTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
 	tests := []struct {
 		name                 string
 		runIDs               []string
@@ -119,9 +100,6 @@ func (s *ArchiveBatchTestSuite) Test_Ok() {
 }
 
 func (s *ArchiveBatchTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name             string
 		request          []string

--- a/tests/integration/golang/aim/run/delete_batch_test.go
+++ b/tests/integration/golang/aim/run/delete_batch_test.go
@@ -8,11 +8,9 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,28 +27,12 @@ func TestDeleteBatchTestSuite(t *testing.T) {
 func (s *DeleteBatchTestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
+	var err error
+	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), s.DefaultExperiment, 10)
 	s.Require().Nil(err)
 }
 
 func (s *DeleteBatchTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name             string
 		runIDs           []string
@@ -101,9 +83,6 @@ func (s *DeleteBatchTestSuite) Test_Ok() {
 }
 
 func (s *DeleteBatchTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name             string
 		request          []string

--- a/tests/integration/golang/aim/run/delete_test.go
+++ b/tests/integration/golang/aim/run/delete_test.go
@@ -8,12 +8,10 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -30,28 +28,12 @@ func TestDeleteRunTestSuite(t *testing.T) {
 func (s *DeleteRunTestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), experiment, 10)
+	var err error
+	s.runs, err = s.RunFixtures.CreateExampleRuns(context.Background(), s.DefaultExperiment, 10)
 	s.Require().Nil(err)
 }
 
 func (s *DeleteRunTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name             string
 		request          request.DeleteRunRequest
@@ -107,9 +89,6 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 }
 
 func (s *DeleteRunTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name    string
 		request request.DeleteRunRequest

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,28 +27,12 @@ func TestGetRunInfoTestSuite(t *testing.T) {
 func (s *GetRunInfoTestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
+	var err error
+	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), s.DefaultExperiment)
 	s.Require().Nil(err)
 }
 
 func (s *GetRunInfoTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name  string
 		runID string
@@ -79,9 +62,6 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 }
 
 func (s *GetRunInfoTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name  string
 		runID string

--- a/tests/integration/golang/aim/run/get_run_metrics_test.go
+++ b/tests/integration/golang/aim/run/get_run_metrics_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,28 +28,12 @@ func TestGetRunMetricsTestSuite(t *testing.T) {
 func (s *GetRunMetricsTestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
 
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
+	var err error
+	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), s.DefaultExperiment)
 	s.Require().Nil(err)
 }
 
 func (s *GetRunMetricsTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name             string
 		runID            string
@@ -106,9 +89,6 @@ func (s *GetRunMetricsTestSuite) Test_Ok() {
 }
 
 func (s *GetRunMetricsTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name  string
 		runID string

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -27,17 +26,6 @@ func TestGetRunsActiveTestSuite(t *testing.T) {
 }
 
 func (s *GetRunsActiveTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name         string
 		wantRunCount int
@@ -53,7 +41,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 			beforeRunFn: func() {
 				experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 					Name:           uuid.New().String(),
-					NamespaceID:    namespace.ID,
+					NamespaceID:    s.DefaultNamespace.ID,
 					LifecycleStage: models.LifecycleStageActive,
 				})
 				s.Require().Nil(err)

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/encoding"
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,29 +28,18 @@ func TestSearchTestSuite(t *testing.T) {
 }
 
 func (s *SearchTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	// create test experiments.
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 
 	experiment2, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           uuid.New().String(),
 		LifecycleStage: models.LifecycleStageActive,
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 	})
 	s.Require().Nil(err)
 

--- a/tests/integration/golang/aim/run/update_run_test.go
+++ b/tests/integration/golang/aim/run/update_run_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -29,28 +28,13 @@ func TestUpdateRunTestSuite(t *testing.T) {
 
 func (s *UpdateRunTestSuite) SetupTest() {
 	s.BaseTestSuite.SetupTest()
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
 
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), experiment)
+	var err error
+	s.run, err = s.RunFixtures.CreateExampleRun(context.Background(), s.DefaultExperiment)
 	s.Require().Nil(err)
 }
 
 func (s *UpdateRunTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name    string
 		request request.UpdateRunRequest
@@ -90,9 +74,6 @@ func (s *UpdateRunTestSuite) Test_Ok() {
 }
 
 func (s *UpdateRunTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	tests := []struct {
 		name        string
 		ID          string

--- a/tests/integration/golang/database/import_test.go
+++ b/tests/integration/golang/database/import_test.go
@@ -163,8 +163,8 @@ func (s *ImportTestSuite) populateDB(db *gorm.DB) {
 }
 
 func (s *ImportTestSuite) TearDownTest() {
-	s.Require().Nil(s.inputRunFixtures.UnloadFixtures())
-	s.Require().Nil(s.outputRunFixtures.UnloadFixtures())
+	s.Require().Nil(s.inputRunFixtures.TruncateTables())
+	s.Require().Nil(s.outputRunFixtures.TruncateTables())
 }
 
 func (s *ImportTestSuite) Test_Ok() {

--- a/tests/integration/golang/database/import_test.go
+++ b/tests/integration/golang/database/import_test.go
@@ -162,12 +162,12 @@ func (s *ImportTestSuite) populateDB(db *gorm.DB) {
 	s.Require().Nil(err)
 }
 
-func (s *ImportTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.inputRunFixtures.UnloadFixtures())
-		s.Require().Nil(s.outputRunFixtures.UnloadFixtures())
-	}()
+func (s *ImportTestSuite) TearDownTest() {
+	s.Require().Nil(s.inputRunFixtures.UnloadFixtures())
+	s.Require().Nil(s.outputRunFixtures.UnloadFixtures())
+}
 
+func (s *ImportTestSuite) Test_Ok() {
 	// source DB should have expected
 	s.validateRowCounts(s.inputDB, s.populatedRowCounts)
 

--- a/tests/integration/golang/fixtures/base.go
+++ b/tests/integration/golang/fixtures/base.go
@@ -13,8 +13,8 @@ type baseFixtures struct {
 	db *gorm.DB
 }
 
-// UnloadFixtures cleans database from the old data.
-func (f baseFixtures) UnloadFixtures() error {
+// TruncateTables cleans database from the old data.
+func (f baseFixtures) TruncateTables() error {
 	for _, table := range []interface{}{
 		database.Dashboard{}, // TODO update to models when available
 		database.App{},       // TODO update to models when available

--- a/tests/integration/golang/helpers/s3.go
+++ b/tests/integration/golang/helpers/s3.go
@@ -11,6 +11,34 @@ import (
 	"github.com/rotisserie/eris"
 )
 
+type S3TestSuite struct {
+	BaseTestSuite
+	Client      *s3.Client
+	testBuckets []string
+}
+
+// NewS3TestSuite creates a new instance of S3TestSuite.
+func NewS3TestSuite(testBuckets ...string) S3TestSuite {
+	return S3TestSuite{
+		testBuckets: testBuckets,
+	}
+}
+
+func (s *S3TestSuite) SetupSuite() {
+	s.BaseTestSuite.SetupSuite()
+
+	client, err := NewS3Client(GetS3EndpointUri())
+	s.Require().Nil(err)
+	s.Client = client
+
+	s.AddSetupHook(func() {
+		s.Require().Nil(s.CreateTestBuckets())
+	})
+	s.AddTearDownHook(func() {
+		s.Require().Nil(s.DeleteTestBuckets())
+	})
+}
+
 // NewS3Client creates new instance of S3 client.
 func NewS3Client(endpoint string) (*s3.Client, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(context.Background(), awsConfig.WithEndpointResolverWithOptions(
@@ -34,10 +62,10 @@ func NewS3Client(endpoint string) (*s3.Client, error) {
 	}), nil
 }
 
-// CreateS3Buckets creates the test buckets.
-func CreateS3Buckets(s3Client *s3.Client, buckets []string) error {
-	for _, bucket := range buckets {
-		_, err := s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
+// CreateTestBuckets creates the test buckets.
+func (s *S3TestSuite) CreateTestBuckets() error {
+	for _, bucket := range s.testBuckets {
+		_, err := s.Client.CreateBucket(context.Background(), &s3.CreateBucketInput{
 			Bucket: aws.String(bucket),
 		})
 		if err != nil {
@@ -47,10 +75,10 @@ func CreateS3Buckets(s3Client *s3.Client, buckets []string) error {
 	return nil
 }
 
-// DeleteS3Buckets deletes the test buckets.
-func DeleteS3Buckets(s3Client *s3.Client, buckets []string) error {
-	for _, bucket := range buckets {
-		if err := deleteBucket(s3Client, bucket); err != nil {
+// DeleteTestBuckets deletes the test buckets.
+func (s *S3TestSuite) DeleteTestBuckets() error {
+	for _, bucket := range s.testBuckets {
+		if err := s.deleteBucket(bucket); err != nil {
 			return eris.Wrapf(err, "failed to delete bucket %q", bucket)
 		}
 	}
@@ -58,10 +86,10 @@ func DeleteS3Buckets(s3Client *s3.Client, buckets []string) error {
 }
 
 // deleteBucket deletes a bucket and its objects.
-func deleteBucket(s3Client *s3.Client, bucket string) error {
+func (s *S3TestSuite) deleteBucket(bucket string) error {
 	// Delete all objects in the bucket
 	var objectIDs []types.ObjectIdentifier
-	paginator := s3.NewListObjectsV2Paginator(s3Client, &s3.ListObjectsV2Input{
+	paginator := s3.NewListObjectsV2Paginator(s.Client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
 	})
 	for paginator.HasMorePages() {
@@ -74,7 +102,7 @@ func deleteBucket(s3Client *s3.Client, bucket string) error {
 		}
 	}
 	if len(objectIDs) > 0 {
-		_, err := s3Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+		_, err := s.Client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
 			Bucket: aws.String(bucket),
 			Delete: &types.Delete{Objects: objectIDs},
 		})
@@ -84,12 +112,12 @@ func deleteBucket(s3Client *s3.Client, bucket string) error {
 	}
 
 	// Delete the bucket
-	if _, err := s3Client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+	if _, err := s.Client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
 		Bucket: aws.String(bucket),
 	}); err != nil {
 		return eris.Wrapf(err, "failed to delete bucket %q", bucket)
 	}
-	waiter := s3.NewBucketNotExistsWaiter(s3Client)
+	waiter := s3.NewBucketNotExistsWaiter(s.Client)
 	if err := waiter.Wait(
 		context.Background(),
 		&s3.HeadBucketInput{

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -1,11 +1,14 @@
 package helpers
 
 import (
+	"context"
 	"time"
 
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 
+	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
+	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/fixtures"
 )
@@ -14,21 +17,28 @@ var db *gorm.DB
 
 type BaseTestSuite struct {
 	suite.Suite
-	AIMClient          func() *HttpClient
-	MlflowClient       func() *HttpClient
-	AdminClient        func() *HttpClient
-	AppFixtures        *fixtures.AppFixtures
-	RunFixtures        *fixtures.RunFixtures
-	TagFixtures        *fixtures.TagFixtures
-	MetricFixtures     *fixtures.MetricFixtures
-	ParamFixtures      *fixtures.ParamFixtures
-	ProjectFixtures    *fixtures.ProjectFixtures
-	DashboardFixtures  *fixtures.DashboardFixtures
-	ExperimentFixtures *fixtures.ExperimentFixtures
-	NamespaceFixtures  *fixtures.NamespaceFixtures
+	AIMClient                   func() *HttpClient
+	MlflowClient                func() *HttpClient
+	AdminClient                 func() *HttpClient
+	AppFixtures                 *fixtures.AppFixtures
+	RunFixtures                 *fixtures.RunFixtures
+	TagFixtures                 *fixtures.TagFixtures
+	MetricFixtures              *fixtures.MetricFixtures
+	ParamFixtures               *fixtures.ParamFixtures
+	ProjectFixtures             *fixtures.ProjectFixtures
+	DashboardFixtures           *fixtures.DashboardFixtures
+	ExperimentFixtures          *fixtures.ExperimentFixtures
+	DefaultExperiment           *models.Experiment
+	NamespaceFixtures           *fixtures.NamespaceFixtures
+	DefaultNamespace            *models.Namespace
+	ResetOnSubTest              bool
+	SkipCreateDefaultNamespace  bool
+	SkipCreateDefaultExperiment bool
+	setupHooks                  []func()
+	tearDownHooks               []func()
 }
 
-func (s *BaseTestSuite) SetupTest() {
+func (s *BaseTestSuite) SetupSuite() {
 	if db == nil {
 		instance, err := database.NewDBProvider(
 			GetDatabaseUri(),
@@ -85,6 +95,80 @@ func (s *BaseTestSuite) SetupTest() {
 	s.Require().Nil(err)
 	s.TagFixtures = tagFixtures
 
-	// by default, unload everything.
+	s.AddSetupHook(s.setup)
+	s.AddTearDownHook(s.tearDown)
+}
+
+func (s *BaseTestSuite) setup() {
 	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+
+	if !s.SkipCreateDefaultNamespace {
+		var err error
+		s.DefaultNamespace, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
+			Code:                "default",
+			DefaultExperimentID: common.GetPointer(int32(0)),
+		})
+		s.Require().Nil(err)
+
+		if !s.SkipCreateDefaultExperiment {
+			s.DefaultExperiment, err = s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
+				Name:           "Default",
+				LifecycleStage: models.LifecycleStageActive,
+				NamespaceID:    s.DefaultNamespace.ID,
+			})
+			s.Require().Nil(err)
+
+			s.DefaultNamespace.DefaultExperimentID = s.DefaultExperiment.ID
+			_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), s.DefaultNamespace)
+			s.Require().Nil(err)
+		}
+	}
+}
+
+func (s *BaseTestSuite) AddSetupHook(hook func()) {
+	s.setupHooks = append(s.setupHooks, hook)
+}
+
+func (s *BaseTestSuite) runSetupHooks() {
+	for _, hook := range s.setupHooks {
+		hook()
+	}
+}
+
+func (s *BaseTestSuite) SetupTest() {
+	if !s.ResetOnSubTest {
+		s.runSetupHooks()
+	}
+}
+
+func (s *BaseTestSuite) SetupSubTest() {
+	if s.ResetOnSubTest {
+		s.runSetupHooks()
+	}
+}
+
+func (s *BaseTestSuite) AddTearDownHook(hook func()) {
+	s.tearDownHooks = append([]func(){hook}, s.tearDownHooks...)
+}
+
+func (s *BaseTestSuite) tearDown() {
+	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+}
+
+func (s *BaseTestSuite) runTearDownHooks() {
+	for _, hook := range s.tearDownHooks {
+		hook()
+	}
+}
+
+func (s *BaseTestSuite) TearDownTest() {
+	if !s.ResetOnSubTest {
+		s.runTearDownHooks()
+	}
+}
+
+func (s *BaseTestSuite) TearDownSubTest() {
+	if s.ResetOnSubTest {
+		s.runTearDownHooks()
+	}
 }

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -100,7 +100,7 @@ func (s *BaseTestSuite) SetupSuite() {
 }
 
 func (s *BaseTestSuite) setup() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.TruncateTables())
 
 	if !s.SkipCreateDefaultNamespace {
 		var err error
@@ -152,7 +152,7 @@ func (s *BaseTestSuite) AddTearDownHook(hook func()) {
 }
 
 func (s *BaseTestSuite) tearDown() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	s.Require().Nil(s.NamespaceFixtures.TruncateTables())
 }
 
 func (s *BaseTestSuite) runTearDownHooks() {

--- a/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
@@ -9,57 +9,27 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
 type GetArtifactGSTestSuite struct {
-	helpers.BaseTestSuite
-	gsClient    *storage.Client
-	testBuckets []string
+	helpers.GSTestSuite
 }
 
 func TestGetArtifactGSTestSuite(t *testing.T) {
 	suite.Run(t, &GetArtifactGSTestSuite{
-		testBuckets: []string{"bucket1", "bucket2"},
+		helpers.NewGSTestSuite("bucket1", "bucket2"),
 	})
-}
-
-func (s *GetArtifactGSTestSuite) SetupSuite() {
-	gsClient, err := helpers.NewGSClient(helpers.GetGSEndpointUri())
-	s.Require().Nil(err)
-	s.gsClient = gsClient
-}
-
-func (s *GetArtifactGSTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest()
-	s.Require().Nil(helpers.CreateGSBuckets(s.gsClient, s.testBuckets))
-}
-
-func (s *GetArtifactGSTestSuite) TearDownTest() {
-	s.Require().Nil(helpers.DeleteGSBuckets(s.gsClient, s.testBuckets))
 }
 
 func (s *GetArtifactGSTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name   string
 		bucket string
@@ -79,7 +49,7 @@ func (s *GetArtifactGSTestSuite) Test_Ok() {
 			// create test experiment
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
-				NamespaceID:      namespace.ID,
+				NamespaceID:      s.DefaultNamespace.ID,
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("gs://%s/1", tt.bucket),
 			})
@@ -98,7 +68,7 @@ func (s *GetArtifactGSTestSuite) Test_Ok() {
 			s.Require().Nil(err)
 
 			// upload artifact root object to GS
-			writer := s.gsClient.Bucket(tt.bucket).Object(
+			writer := s.Client.Bucket(tt.bucket).Object(
 				fmt.Sprintf("/1/%s/artifacts/artifact.txt", runID),
 			).NewWriter(context.Background())
 			_, err = writer.Write([]byte("content"))
@@ -106,7 +76,7 @@ func (s *GetArtifactGSTestSuite) Test_Ok() {
 			s.Require().Nil(writer.Close())
 
 			// upload artifact subdir object to GS
-			writer = s.gsClient.Bucket(tt.bucket).Object(
+			writer = s.Client.Bucket(tt.bucket).Object(
 				fmt.Sprintf("/1/%s/artifacts/artifact/artifact.txt", runID),
 			).NewWriter(context.Background())
 			_, err = writer.Write([]byte("subdir-object-content"))
@@ -153,21 +123,10 @@ func (s *GetArtifactGSTestSuite) Test_Ok() {
 }
 
 func (s *GetArtifactGSTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	// create test experiment
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment In Bucket bucket1",
-		NamespaceID:      namespace.ID,
+		NamespaceID:      s.DefaultNamespace.ID,
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "gs://bucket1/1",
 	})
@@ -187,7 +146,7 @@ func (s *GetArtifactGSTestSuite) Test_Error() {
 
 	// upload artifact subdir object to GS
 	s.Require().Nil(err)
-	writer := s.gsClient.Bucket("bucket1").Object(
+	writer := s.Client.Bucket("bucket1").Object(
 		fmt.Sprintf("1/%s/artifacts/artifact/artifact.file", runID),
 	).NewWriter(context.Background())
 	_, err = writer.Write([]byte("content"))

--- a/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -32,17 +31,6 @@ func TestGetArtifactLocalTestSuite(t *testing.T) {
 }
 
 func (s *GetArtifactLocalTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name   string
 		prefix string
@@ -63,7 +51,7 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 			experimentArtifactDir := s.T().TempDir()
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Path %s", experimentArtifactDir),
-				NamespaceID:      namespace.ID,
+				NamespaceID:      s.DefaultNamespace.ID,
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("%s%s", tt.prefix, experimentArtifactDir),
 			})
@@ -132,22 +120,11 @@ func (s *GetArtifactLocalTestSuite) Test_Ok() {
 }
 
 func (s *GetArtifactLocalTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	// create test experiment
 	experimentArtifactDir := s.T().TempDir()
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             fmt.Sprintf("Test Experiment In Path %s", experimentArtifactDir),
-		NamespaceID:      namespace.ID,
+		NamespaceID:      s.DefaultNamespace.ID,
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: experimentArtifactDir,
 	})

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -17,49 +17,21 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
 type GetArtifactS3TestSuite struct {
-	helpers.BaseTestSuite
-	s3Client    *s3.Client
-	testBuckets []string
+	helpers.S3TestSuite
 }
 
 func TestGetArtifactS3TestSuite(t *testing.T) {
 	suite.Run(t, &GetArtifactS3TestSuite{
-		testBuckets: []string{"bucket1", "bucket2"},
+		helpers.NewS3TestSuite("bucket1", "bucket2"),
 	})
-}
-
-func (s *GetArtifactS3TestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest()
-
-	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
-	s.Require().Nil(err)
-	s.Require().Nil(helpers.CreateS3Buckets(s3Client, s.testBuckets))
-
-	s.s3Client = s3Client
-}
-
-func (s *GetArtifactS3TestSuite) TearDownTest() {
-	s.Require().Nil(helpers.DeleteS3Buckets(s.s3Client, s.testBuckets))
 }
 
 func (s *GetArtifactS3TestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name   string
 		bucket string
@@ -79,7 +51,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 			// create test experiment
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
-				NamespaceID:      namespace.ID,
+				NamespaceID:      s.DefaultNamespace.ID,
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("s3://%s/1", tt.bucket),
 			})
@@ -103,7 +75,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 				Body:   strings.NewReader("content"),
 				Bucket: aws.String(tt.bucket),
 			}
-			_, err = s.s3Client.PutObject(context.Background(), putObjReq)
+			_, err = s.Client.PutObject(context.Background(), putObjReq)
 			s.Require().Nil(err)
 
 			// upload artifact subdir object to S3
@@ -115,7 +87,7 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 				Body:   strings.NewReader("subdir-object-content"),
 				Bucket: aws.String(tt.bucket),
 			}
-			_, err = s.s3Client.PutObject(context.Background(), putObjReq)
+			_, err = s.Client.PutObject(context.Background(), putObjReq)
 			s.Require().Nil(err)
 
 			// make API call for root object
@@ -158,21 +130,10 @@ func (s *GetArtifactS3TestSuite) Test_Ok() {
 }
 
 func (s *GetArtifactS3TestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	// create test experiment
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:             "Test Experiment In Bucket bucket1",
-		NamespaceID:      namespace.ID,
+		NamespaceID:      s.DefaultNamespace.ID,
 		LifecycleStage:   models.LifecycleStageActive,
 		ArtifactLocation: "s3://bucket1/1",
 	})
@@ -196,7 +157,7 @@ func (s *GetArtifactS3TestSuite) Test_Error() {
 		Body:   strings.NewReader("content"),
 		Bucket: aws.String("bucket1"),
 	}
-	_, err = s.s3Client.PutObject(context.Background(), putObjReq)
+	_, err = s.Client.PutObject(context.Background(), putObjReq)
 	s.Require().Nil(err)
 
 	tests := []struct {

--- a/tests/integration/golang/mlflow/artifact/list_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_gs_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
@@ -16,50 +15,21 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
 type ListArtifactGSTestSuite struct {
-	helpers.BaseTestSuite
-	gsClient    *storage.Client
-	testBuckets []string
+	helpers.GSTestSuite
 }
 
 func TestListArtifactGSTestSuite(t *testing.T) {
 	suite.Run(t, &ListArtifactGSTestSuite{
-		testBuckets: []string{"bucket1", "bucket2"},
+		helpers.NewGSTestSuite("bucket1", "bucket2"),
 	})
-}
-
-func (s *ListArtifactGSTestSuite) SetupSuite() {
-	gsClient, err := helpers.NewGSClient(helpers.GetGSEndpointUri())
-	s.Require().Nil(err)
-	s.gsClient = gsClient
-}
-
-func (s *ListArtifactGSTestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest()
-	s.Require().Nil(helpers.CreateGSBuckets(s.gsClient, s.testBuckets))
-}
-
-func (s *ListArtifactGSTestSuite) TearDownTest() {
-	s.Require().Nil(helpers.DeleteGSBuckets(s.gsClient, s.testBuckets))
 }
 
 func (s *ListArtifactGSTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name   string
 		bucket string
@@ -79,7 +49,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			// 1. create test experiment.
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
-				NamespaceID:      namespace.ID,
+				NamespaceID:      s.DefaultNamespace.ID,
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("gs://%s/1", tt.bucket),
 			})
@@ -98,7 +68,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			s.Require().Nil(err)
 
 			// 3. upload artifact objects to GS.
-			writer := s.gsClient.Bucket(
+			writer := s.Client.Bucket(
 				tt.bucket,
 			).Object(
 				fmt.Sprintf("1/%s/artifacts/artifact.txt", runID),
@@ -109,7 +79,7 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 			s.Require().Nil(err)
 			s.Require().Nil(writer.Close())
 
-			writer = s.gsClient.Bucket(
+			writer = s.Client.Bucket(
 				tt.bucket,
 			).Object(
 				fmt.Sprintf("1/%s/artifacts/artifact/artifact.txt", runID),
@@ -204,17 +174,6 @@ func (s *ListArtifactGSTestSuite) Test_Ok() {
 }
 
 func (s *ListArtifactGSTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/artifact/list_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_local_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -32,17 +31,6 @@ func TestListArtifactLocalTestSuite(t *testing.T) {
 }
 
 func (s *ListArtifactLocalTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name   string
 		prefix string
@@ -63,7 +51,7 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 			experimentArtifactDir := s.T().TempDir()
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Path %s", experimentArtifactDir),
-				NamespaceID:      namespace.ID,
+				NamespaceID:      s.DefaultNamespace.ID,
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("%s%s", tt.prefix, experimentArtifactDir),
 			})
@@ -177,17 +165,6 @@ func (s *ListArtifactLocalTestSuite) Test_Ok() {
 }
 
 func (s *ListArtifactLocalTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -17,52 +17,21 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
 type ListArtifactS3TestSuite struct {
-	helpers.BaseTestSuite
-	s3Client    *s3.Client
-	testBuckets []string
+	helpers.S3TestSuite
 }
 
 func TestListArtifactS3TestSuite(t *testing.T) {
 	suite.Run(t, &ListArtifactS3TestSuite{
-		testBuckets: []string{"bucket1", "bucket2"},
+		helpers.NewS3TestSuite("bucket1", "bucket2"),
 	})
-}
-
-func (s *ListArtifactS3TestSuite) SetupTest() {
-	s.BaseTestSuite.SetupTest()
-
-	s3Client, err := helpers.NewS3Client(helpers.GetS3EndpointUri())
-	s.Require().Nil(err)
-
-	err = helpers.CreateS3Buckets(s3Client, s.testBuckets)
-	s.Require().Nil(err)
-
-	s.s3Client = s3Client
-}
-
-func (s *ListArtifactS3TestSuite) TearDownTest() {
-	err := helpers.DeleteS3Buckets(s.s3Client, s.testBuckets)
-	s.Require().Nil(err)
 }
 
 func (s *ListArtifactS3TestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name   string
 		bucket string
@@ -82,7 +51,7 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 			// 1. create test experiment.
 			experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 				Name:             fmt.Sprintf("Test Experiment In Bucket %s", tt.bucket),
-				NamespaceID:      namespace.ID,
+				NamespaceID:      s.DefaultNamespace.ID,
 				LifecycleStage:   models.LifecycleStageActive,
 				ArtifactLocation: fmt.Sprintf("s3://%s/1", tt.bucket),
 			})
@@ -101,13 +70,13 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 			s.Require().Nil(err)
 
 			// 3. upload artifact objects to S3.
-			_, err = s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+			_, err = s.Client.PutObject(context.Background(), &s3.PutObjectInput{
 				Key:    aws.String(fmt.Sprintf("1/%s/artifacts/artifact.file1", runID)),
 				Body:   strings.NewReader("contentX"),
 				Bucket: aws.String(tt.bucket),
 			})
 			s.Require().Nil(err)
-			_, err = s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
+			_, err = s.Client.PutObject(context.Background(), &s3.PutObjectInput{
 				Key:    aws.String(fmt.Sprintf("1/%s/artifacts/artifact.dir/artifact.file2", runID)),
 				Body:   strings.NewReader("contentXX"),
 				Bucket: aws.String(tt.bucket),
@@ -197,17 +166,6 @@ func (s *ListArtifactS3TestSuite) Test_Ok() {
 }
 
 func (s *ListArtifactS3TestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/experiment/create_test.go
+++ b/tests/integration/golang/mlflow/experiment/create_test.go
@@ -3,7 +3,6 @@
 package experiment
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -13,8 +12,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
@@ -23,21 +20,14 @@ type CreateExperimentTestSuite struct {
 }
 
 func TestCreateExperimentTestSuite(t *testing.T) {
-	suite.Run(t, new(CreateExperimentTestSuite))
+	suite.Run(t, &CreateExperimentTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *CreateExperimentTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	req := request.CreateExperimentRequest{
 		Name:             "ExperimentName",
 		ArtifactLocation: "/artifact/location",
@@ -68,17 +58,6 @@ func (s *CreateExperimentTestSuite) Test_Ok() {
 }
 
 func (s *CreateExperimentTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/experiment/get_by_name_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_by_name_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -25,21 +24,15 @@ type GetExperimentByNameTestSuite struct {
 }
 
 func TestGetExperimentByNameTestSuite(t *testing.T) {
-	suite.Run(t, new(GetExperimentByNameTestSuite))
+	suite.Run(t, &GetExperimentByNameTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *GetExperimentByNameTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	// 1. prepare database with test data.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
 		Tags: []models.ExperimentTag{
@@ -48,7 +41,7 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 				Value: "value1",
 			},
 		},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 		CreationTime: sql.NullInt64{
 			Int64: time.Now().UTC().UnixMilli(),
 			Valid: true,
@@ -93,17 +86,6 @@ func (s *GetExperimentByNameTestSuite) Test_Ok() {
 }
 
 func (s *GetExperimentByNameTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/experiment/get_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -25,22 +24,15 @@ type GetExperimentTestSuite struct {
 }
 
 func TestGetExperimentTestSuite(t *testing.T) {
-	suite.Run(t, new(GetExperimentTestSuite))
+	suite.Run(t, &GetExperimentTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *GetExperimentTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
 	// 1. prepare database with test data.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name: "Test Experiment",
 		Tags: []models.ExperimentTag{
@@ -49,7 +41,7 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 				Value: "value1",
 			},
 		},
-		NamespaceID: namespace.ID,
+		NamespaceID: s.DefaultNamespace.ID,
 		CreationTime: sql.NullInt64{
 			Int64: time.Now().UTC().UnixMilli(),
 			Valid: true,
@@ -93,17 +85,6 @@ func (s *GetExperimentTestSuite) Test_Ok() {
 }
 
 func (s *GetExperimentTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/experiment/restore_test.go
+++ b/tests/integration/golang/mlflow/experiment/restore_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -24,24 +23,18 @@ type RestoreExperimentTestSuite struct {
 }
 
 func TestRestoreExperimentTestSuite(t *testing.T) {
-	suite.Run(t, new(RestoreExperimentTestSuite))
+	suite.Run(t, &RestoreExperimentTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *RestoreExperimentTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	// 1. prepare database with test data.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           "Test Experiment",
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
 	s.Require().Nil(err)
@@ -66,24 +59,13 @@ func (s *RestoreExperimentTestSuite) Test_Ok() {
 
 	// 3. check actual API response.
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
-		context.Background(), namespace.ID, *experiment.ID,
+		context.Background(), s.DefaultNamespace.ID, *experiment.ID,
 	)
 	s.Require().Nil(err)
 	s.Equal(models.LifecycleStageActive, exp.LifecycleStage)
 }
 
 func (s *RestoreExperimentTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/experiment/search_test.go
+++ b/tests/integration/golang/mlflow/experiment/search_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -22,21 +21,15 @@ type SearchExperimentsTestSuite struct {
 }
 
 func TestSearchExperimentsTestSuite(t *testing.T) {
-	suite.Run(t, new(SearchExperimentsTestSuite))
+	suite.Run(t, &SearchExperimentsTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *SearchExperimentsTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	// 1. prepare database with test data.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiments := []models.Experiment{
 		{
 			Name:           "Test Experiment 1",
@@ -66,7 +59,7 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 	for _, ex := range experiments {
 		_, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 			Name:           ex.Name,
-			NamespaceID:    namespace.ID,
+			NamespaceID:    s.DefaultNamespace.ID,
 			LifecycleStage: ex.LifecycleStage,
 		})
 		s.Require().Nil(err)
@@ -143,17 +136,6 @@ func (s *SearchExperimentsTestSuite) Test_Ok() {
 }
 
 func (s *SearchExperimentsTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/experiment/update_test.go
+++ b/tests/integration/golang/mlflow/experiment/update_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -23,24 +22,18 @@ type UpdateExperimentTestSuite struct {
 }
 
 func TestUpdateExperimentTestSuite(t *testing.T) {
-	suite.Run(t, new(UpdateExperimentTestSuite))
+	suite.Run(t, &UpdateExperimentTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultExperiment: true,
+		},
+	})
 }
 
 func (s *UpdateExperimentTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
 	// 1. prepare database with test data.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           "Test Experiment",
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -62,24 +55,13 @@ func (s *UpdateExperimentTestSuite) Test_Ok() {
 	)
 
 	exp, err := s.ExperimentFixtures.GetByNamespaceIDAndExperimentID(
-		context.Background(), namespace.ID, *experiment.ID,
+		context.Background(), s.DefaultNamespace.ID, *experiment.ID,
 	)
 	s.Require().Nil(err)
 	s.Equal("Test Updated Experiment", exp.Name)
 }
 
 func (s *UpdateExperimentTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	testData := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/service/metric"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
@@ -29,19 +28,9 @@ func TestGetHistoriesTestSuite(t *testing.T) {
 }
 
 func (s *GetHistoriesTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           "Test Experiment",
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -130,17 +119,6 @@ func (s *GetHistoriesTestSuite) Test_Ok() {
 }
 
 func (s *GetHistoriesTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/service/metric"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
@@ -27,19 +26,9 @@ func TestGetHistoriesBulkTestSuite(t *testing.T) {
 }
 
 func (s *GetHistoriesBulkTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           "Test Experiment",
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -123,17 +112,6 @@ func (s *GetHistoriesBulkTestSuite) Test_Ok() {
 }
 
 func (s *GetHistoriesBulkTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -26,19 +25,9 @@ func TestGetHistoryTestSuite(t *testing.T) {
 }
 
 func (s *GetHistoryTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
 		Name:           "Test Experiment",
-		NamespaceID:    namespace.ID,
+		NamespaceID:    s.DefaultNamespace.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -92,17 +81,6 @@ func (s *GetHistoryTestSuite) Test_Ok() {
 }
 
 func (s *GetHistoryTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
@@ -35,11 +35,12 @@ type ExperimentFlowTestSuite struct {
 // - `GET /experiments/get-by-name`
 // - `POST /experiments/set-experiment-tag`
 func TestExperimentFlowTestSuite(t *testing.T) {
-	suite.Run(t, new(ExperimentFlowTestSuite))
-}
-
-func (s *ExperimentFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &ExperimentFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *ExperimentFlowTestSuite) Test_Ok() {
@@ -95,11 +96,8 @@ func (s *ExperimentFlowTestSuite) Test_Ok() {
 
 	// delete everything before the test, because when service starts under the hood we create
 	// default namespace and experiment, so it could lead to the problems with actual tests.
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/mlflow/namespace/flows/metric_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/metric_test.go
@@ -28,11 +28,12 @@ type MetricFlowTestSuite struct {
 // - `GET /metrics/get-history-bulk`
 // - `POST /metrics/get-histories` - TODO:dsuhinin we need firstly to create proper decoder.
 func TestMetricFlowTestSuite(t *testing.T) {
-	suite.Run(t, new(MetricFlowTestSuite))
-}
-
-func (s *MetricFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &MetricFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *MetricFlowTestSuite) Test_Ok() {
@@ -88,8 +89,6 @@ func (s *MetricFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/mlflow/namespace/flows/run_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/run_test.go
@@ -37,11 +37,12 @@ type RunFlowTestSuite struct {
 // - `POST /runs/delete-tag`
 // - `POST /runs/log-batch`
 func TestRunFlowTestSuite(t *testing.T) {
-	suite.Run(t, new(RunFlowTestSuite))
-}
-
-func (s *RunFlowTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &RunFlowTestSuite{
+		helpers.BaseTestSuite{
+			ResetOnSubTest:             true,
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *RunFlowTestSuite) Test_Ok() {
@@ -97,8 +98,6 @@ func (s *RunFlowTestSuite) Test_Ok() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			defer s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-
 			// 1. setup data under the test.
 			namespace1, namespace2 := tt.setup()
 			namespace1, err := s.NamespaceFixtures.CreateNamespace(context.Background(), namespace1)

--- a/tests/integration/golang/mlflow/namespace/namespace_test.go
+++ b/tests/integration/golang/mlflow/namespace/namespace_test.go
@@ -18,11 +18,11 @@ type NamespaceTestSuite struct {
 }
 
 func TestNamespaceTestSuite(t *testing.T) {
-	suite.Run(t, new(NamespaceTestSuite))
-}
-
-func (s *NamespaceTestSuite) TearDownTest() {
-	s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
+	suite.Run(t, &NamespaceTestSuite{
+		helpers.BaseTestSuite{
+			SkipCreateDefaultNamespace: true,
+		},
+	})
 }
 
 func (s *NamespaceTestSuite) Test_Error() {

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -29,64 +29,16 @@ func TestCreateRunTestSuite(t *testing.T) {
 }
 
 func (s *CreateRunTestSuite) Test_DefaultNamespace_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create test experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.successCases(namespace, experiment, false, *experiment.ID)
+	s.successCases(s.DefaultNamespace, s.DefaultExperiment, false, *s.DefaultExperiment.ID)
 }
 
 func (s *CreateRunTestSuite) Test_DefaultNamespaceExperimentZero_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create test experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// update default experiment id for namespace.
-	namespace.DefaultExperimentID = experiment.ID
-	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	s.Require().Nil(err)
-
-	s.successCases(namespace, experiment, false, int32(0))
+	s.successCases(s.DefaultNamespace, s.DefaultExperiment, false, int32(0))
 }
 
 func (s *CreateRunTestSuite) Test_CustomNamespace_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
 	// create test experiment.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
@@ -103,13 +55,8 @@ func (s *CreateRunTestSuite) Test_CustomNamespace_Ok() {
 }
 
 func (s *CreateRunTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
 	// create test experiment.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
 		Code:                "custom",
 		DefaultExperimentID: common.GetPointer(int32(0)),
 	})
@@ -192,29 +139,6 @@ func (s *CreateRunTestSuite) successCases(
 }
 
 func (s *CreateRunTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// set namespace default experiment.
-	namespace.DefaultExperimentID = experiment.ID
-	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name      string
 		error     *api.ErrorResponse
@@ -235,7 +159,7 @@ func (s *CreateRunTestSuite) Test_Error() {
 			name:      "CreateRunWithNotExistingNamespaceAndExistingExperimentID",
 			namespace: "not_existing_namespace",
 			request: request.CreateRunRequest{
-				ExperimentID: fmt.Sprintf("%d", *experiment.ID),
+				ExperimentID: fmt.Sprintf("%d", *s.DefaultExperiment.ID),
 			},
 			error: api.NewResourceDoesNotExistError(
 				`unable to find namespace with code: not_existing_namespace`,

--- a/tests/integration/golang/mlflow/run/delete_tag_test.go
+++ b/tests/integration/golang/mlflow/run/delete_tag_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -30,26 +29,7 @@ func TestDeleteRunTagTestSuite(t *testing.T) {
 }
 
 func (s *DeleteRunTagTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create test experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// create test run for the experiment
+	// create test run.
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:     strings.ReplaceAll(uuid.New().String(), "-", ""),
 		Name:   "TestRun",
@@ -64,7 +44,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 		},
 		SourceType:     "JOB",
 		ArtifactURI:    "artifact_uri",
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -121,26 +101,7 @@ func (s *DeleteRunTagTestSuite) Test_Ok() {
 }
 
 func (s *DeleteRunTagTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	// create test experiment.
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// create test run for the experiment
+	// create test run.
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:     strings.ReplaceAll(uuid.New().String(), "-", ""),
 		Name:   "TestRun",
@@ -155,7 +116,7 @@ func (s *DeleteRunTagTestSuite) Test_Error() {
 		},
 		SourceType:     "JOB",
 		ArtifactURI:    "artifact_uri",
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)

--- a/tests/integration/golang/mlflow/run/delete_test.go
+++ b/tests/integration/golang/mlflow/run/delete_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -28,32 +27,13 @@ func TestDeleteRunTestSuite(t *testing.T) {
 }
 
 func (s *DeleteRunTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create experiment
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
 	// create run for the experiment
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
 		Name:           "TestRun",
 		Status:         models.StatusRunning,
 		SourceType:     "JOB",
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -94,17 +74,6 @@ func (s *DeleteRunTestSuite) Test_Ok() {
 }
 
 func (s *DeleteRunTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		request request.DeleteRunRequest

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/response"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -30,26 +29,7 @@ func TestGetRunTestSuite(t *testing.T) {
 }
 
 func (s *GetRunTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create test experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// create test run for the experiment
+	// create test run.
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:     strings.ReplaceAll(uuid.New().String(), "-", ""),
 		Name:   "TestRun",
@@ -64,7 +44,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 		},
 		SourceType:     "JOB",
 		ArtifactURI:    "artifact_uri",
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -112,7 +92,7 @@ func (s *GetRunTestSuite) Test_Ok() {
 	s.NotEmpty(resp.Run.Info.ID)
 	s.NotEmpty(resp.Run.Info.UUID)
 	s.Equal("TestRun", resp.Run.Info.Name)
-	s.Equal(fmt.Sprintf("%d", *experiment.ID), resp.Run.Info.ExperimentID)
+	s.Equal(fmt.Sprintf("%d", *s.DefaultExperiment.ID), resp.Run.Info.ExperimentID)
 	s.Equal(int64(1234567890), resp.Run.Info.StartTime)
 	s.Equal(int64(1234567899), resp.Run.Info.EndTime)
 	s.Equal(string(models.StatusRunning), resp.Run.Info.Status)
@@ -141,17 +121,6 @@ func (s *GetRunTestSuite) Test_Ok() {
 }
 
 func (s *GetRunTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,27 +28,9 @@ func TestLogBatchTestSuite(t *testing.T) {
 }
 
 func (s *LogBatchTestSuite) TestTags_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
@@ -93,27 +74,9 @@ func (s *LogBatchTestSuite) TestTags_Ok() {
 }
 
 func (s *LogBatchTestSuite) TestParams_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
@@ -200,27 +163,9 @@ func (s *LogBatchTestSuite) TestParams_Ok() {
 }
 
 func (s *LogBatchTestSuite) TestMetrics_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
@@ -378,27 +323,9 @@ func (s *LogBatchTestSuite) TestMetrics_Ok() {
 }
 
 func (s *LogBatchTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -28,14 +28,13 @@ func TestLogMetricTestSuite(t *testing.T) {
 }
 
 func (s *LogMetricTestSuite) Test_Ok() {
-	run := &models.Run{
+	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
 		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
-	}
-	run, err := s.RunFixtures.CreateRun(context.Background(), run)
+	})
 	s.Require().Nil(err)
 
 	req := request.LogMetricRequest{
@@ -110,14 +109,13 @@ func (s *LogMetricTestSuite) Test_Error() {
 			},
 			error: api.NewInvalidParameterValueError(`invalid metric value 'incorrect_value'`),
 			setupDatabase: func() string {
-				run := &models.Run{
+				run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 					ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
 					ExperimentID:   *s.DefaultExperiment.ID,
 					SourceType:     "JOB",
 					LifecycleStage: models.LifecycleStageActive,
 					Status:         models.StatusRunning,
-				}
-				run, err := s.RunFixtures.CreateRun(context.Background(), run)
+				})
 				s.Require().Nil(err)
 				return run.ID
 			},

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,33 +28,14 @@ func TestLogMetricTestSuite(t *testing.T) {
 }
 
 func (s *LogMetricTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment := &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	}
-	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	s.Require().Nil(err)
-
 	run := &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
 	}
-	run, err = s.RunFixtures.CreateRun(context.Background(), run)
+	run, err := s.RunFixtures.CreateRun(context.Background(), run)
 	s.Require().Nil(err)
 
 	req := request.LogMetricRequest{
@@ -99,24 +79,11 @@ func (s *LogMetricTestSuite) Test_Error() {
 		error         *api.ErrorResponse
 		request       request.LogMetricRequest
 		setupDatabase func() string
-		cleanDatabase func()
 	}{
 		{
 			name:    "EmptyOrIncorrectRunID",
 			request: request.LogMetricRequest{},
 			error:   api.NewInvalidParameterValueError("Missing value for required parameter 'run_id'"),
-			setupDatabase: func() string {
-				_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-					ID:                  1,
-					Code:                "default",
-					DefaultExperimentID: common.GetPointer(int32(0)),
-				})
-				s.Require().Nil(err)
-				return ""
-			},
-			cleanDatabase: func() {
-				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-			},
 		},
 		{
 			name: "EmptyOrIncorrectKey",
@@ -124,18 +91,6 @@ func (s *LogMetricTestSuite) Test_Error() {
 				RunID: "id",
 			},
 			error: api.NewInvalidParameterValueError("Missing value for required parameter 'key'"),
-			setupDatabase: func() string {
-				_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-					ID:                  1,
-					Code:                "default",
-					DefaultExperimentID: common.GetPointer(int32(0)),
-				})
-				s.Require().Nil(err)
-				return ""
-			},
-			cleanDatabase: func() {
-				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-			},
 		},
 		{
 			name: "NotFoundRun",
@@ -145,18 +100,6 @@ func (s *LogMetricTestSuite) Test_Error() {
 				Timestamp: 123456789,
 			},
 			error: api.NewResourceDoesNotExistError("unable to find run 'id'"),
-			setupDatabase: func() string {
-				_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-					ID:                  1,
-					Code:                "default",
-					DefaultExperimentID: common.GetPointer(int32(0)),
-				})
-				s.Require().Nil(err)
-				return ""
-			},
-			cleanDatabase: func() {
-				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-			},
 		},
 		{
 			name: "InvalidMetricValue",
@@ -167,34 +110,16 @@ func (s *LogMetricTestSuite) Test_Error() {
 			},
 			error: api.NewInvalidParameterValueError(`invalid metric value 'incorrect_value'`),
 			setupDatabase: func() string {
-				namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-					ID:                  1,
-					Code:                "default",
-					DefaultExperimentID: common.GetPointer(int32(0)),
-				})
-				s.Require().Nil(err)
-
-				experiment := &models.Experiment{
-					Name:           uuid.New().String(),
-					NamespaceID:    namespace.ID,
-					LifecycleStage: models.LifecycleStageActive,
-				}
-				_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-				s.Require().Nil(err)
-
 				run := &models.Run{
 					ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-					ExperimentID:   *experiment.ID,
+					ExperimentID:   *s.DefaultExperiment.ID,
 					SourceType:     "JOB",
 					LifecycleStage: models.LifecycleStageActive,
 					Status:         models.StatusRunning,
 				}
-				run, err = s.RunFixtures.CreateRun(context.Background(), run)
+				run, err := s.RunFixtures.CreateRun(context.Background(), run)
 				s.Require().Nil(err)
 				return run.ID
-			},
-			cleanDatabase: func() {
-				s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
 			},
 		},
 	}
@@ -220,11 +145,6 @@ func (s *LogMetricTestSuite) Test_Error() {
 				),
 			)
 			s.Equal(tt.error.Error(), resp.Error())
-
-			// if cleanDatabase has been provided then clean database after the test.
-			if tt.cleanDatabase != nil {
-				tt.cleanDatabase()
-			}
 		})
 	}
 }

--- a/tests/integration/golang/mlflow/run/log_parameter_test.go
+++ b/tests/integration/golang/mlflow/run/log_parameter_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -29,33 +28,13 @@ func TestLogParamTestSuite(t *testing.T) {
 }
 
 func (s *LogParamTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment := &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	}
-	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	s.Require().Nil(err)
-
-	run := &models.Run{
+	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
-	}
-	run, err = s.RunFixtures.CreateRun(context.Background(), run)
+	})
 	s.Require().Nil(err)
 
 	req := request.LogParamRequest{
@@ -98,33 +77,13 @@ func (s *LogParamTestSuite) Test_Ok() {
 }
 
 func (s *LogParamTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment := &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	}
-	_, err = s.ExperimentFixtures.CreateExperiment(context.Background(), experiment)
-	s.Require().Nil(err)
-
-	run := &models.Run{
+	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:             strings.ReplaceAll(uuid.New().String(), "-", ""),
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		SourceType:     "JOB",
 		LifecycleStage: models.LifecycleStageActive,
 		Status:         models.StatusRunning,
-	}
-	run, err = s.RunFixtures.CreateRun(context.Background(), run)
+	})
 	s.Require().Nil(err)
 
 	// setup param OK

--- a/tests/integration/golang/mlflow/run/restore_test.go
+++ b/tests/integration/golang/mlflow/run/restore_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -30,26 +29,7 @@ func TestRestoreRunTestSuite(t *testing.T) {
 }
 
 func (s *RestoreRunTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create test experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// create test run for the experiment
+	// create test run.
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:     strings.ReplaceAll(uuid.New().String(), "-", ""),
 		Name:   "TestRun",
@@ -64,7 +44,7 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 		},
 		SourceType:     "JOB",
 		ArtifactURI:    "artifact_uri",
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
 	s.Require().Nil(err)
@@ -111,17 +91,6 @@ func (s *RestoreRunTestSuite) Test_Ok() {
 }
 
 func (s *RestoreRunTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse

--- a/tests/integration/golang/mlflow/run/search_test.go
+++ b/tests/integration/golang/mlflow/run/search_test.go
@@ -31,61 +31,14 @@ func TestSearchTestSuite(t *testing.T) {
 }
 
 func (s *SearchTestSuite) Test_DefaultNamespace_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create default namespace and experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	s.testCases(namespace, experiment, false, *experiment.ID)
+	s.testCases(s.DefaultNamespace, s.DefaultExperiment, false, *s.DefaultExperiment.ID)
 }
 
-func (s *SearchTestSuite) Test_DefaultNamespaceExerimentZero_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create default namespace and experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// update default experiment id.
-	namespace.DefaultExperimentID = experiment.ID
-	_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), namespace)
-	s.Require().Nil(err)
-
-	s.testCases(namespace, experiment, false, int32(0))
+func (s *SearchTestSuite) Test_DefaultNamespaceExperimentZero_Ok() {
+	s.testCases(s.DefaultNamespace, s.DefaultExperiment, false, int32(0))
 }
 
 func (s *SearchTestSuite) Test_CustomNamespace_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
 	// create custom namespace and experiment.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		Code:                "custom",
@@ -104,10 +57,6 @@ func (s *SearchTestSuite) Test_CustomNamespace_Ok() {
 }
 
 func (s *SearchTestSuite) Test_CustomNamespaceExperimentZero_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
 	// create custom namespace and experiment.
 	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
 		Code:                "custom",

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api/request"
-	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
@@ -30,26 +29,7 @@ func TestSetRunTagTestSuite(t *testing.T) {
 }
 
 func (s *SetRunTagTestSuite) Test_Ok() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	// create test experiment.
-	namespace, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
-	experiment, err := s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-		Name:           uuid.New().String(),
-		NamespaceID:    namespace.ID,
-		LifecycleStage: models.LifecycleStageActive,
-	})
-	s.Require().Nil(err)
-
-	// create test run for the experiment
+	// create test run.
 	run, err := s.RunFixtures.CreateRun(context.Background(), &models.Run{
 		ID:     strings.ReplaceAll(uuid.New().String(), "-", ""),
 		Name:   "TestRun",
@@ -64,7 +44,7 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 		},
 		SourceType:     "JOB",
 		ArtifactURI:    "artifact_uri",
-		ExperimentID:   *experiment.ID,
+		ExperimentID:   *s.DefaultExperiment.ID,
 		LifecycleStage: models.LifecycleStageActive,
 	})
 	s.Require().Nil(err)
@@ -102,17 +82,6 @@ func (s *SetRunTagTestSuite) Test_Ok() {
 }
 
 func (s *SetRunTagTestSuite) Test_Error() {
-	defer func() {
-		s.Require().Nil(s.NamespaceFixtures.UnloadFixtures())
-	}()
-
-	_, err := s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-		ID:                  1,
-		Code:                "default",
-		DefaultExperimentID: common.GetPointer(int32(0)),
-	})
-	s.Require().Nil(err)
-
 	tests := []struct {
 		name    string
 		error   *api.ErrorResponse


### PR DESCRIPTION
This PR is a big refactor of the way we setup our integration tests. It aims at reducing some of the boilerplate we have in each test suite. I would recommend reviewing by looking at the 4 commits individually.
* [Refactor BaseTestSuite helper to provide setup/teardown](https://github.com/G-Research/fasttrackml/pull/645/commits/b371762452289ed61d508870803ed35fd3326b13) lays down the foundation for this refactor 🏗️ 
* [Refactor bucket storage provider helpers to provide setup/teardown](https://github.com/G-Research/fasttrackml/pull/645/commits/65b4ebe0f11efb59318944cfad06ded773870516) applies these principles to the GCP and S3 helpers 🔨 
* [Adapt all tests to use refactored setup/teardown](https://github.com/G-Research/fasttrackml/pull/645/commits/c38a5a0610a4b6a21252abafecb4ecccc8a58074) is the one where the boilerplate code gets removed/adapted 🗑️
* [Rename UnloadFixtures to TruncateTables](https://github.com/G-Research/fasttrackml/pull/645/commits/48fac842be1bdb7012f0b215da7c291af4525687) is self-explanatory 😄