### PR TITLE
Default experiments should be named "Default"

### DIFF
--- a/pkg/api/admin/service/namespace/service.go
+++ b/pkg/api/admin/service/namespace/service.go
@@ -2,7 +2,6 @@ package namespace
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rotisserie/eris"
 
@@ -49,7 +48,7 @@ func (s Service) CreateNamespace(ctx context.Context, code, description string) 
 		return nil, eris.Wrap(err, "error validating namespace")
 	}
 	exp := &models.Experiment{
-		Name:           fmt.Sprintf("%s-exp", code),
+		Name:           "Default",
 		LifecycleStage: models.LifecycleStageActive,
 	}
 	namespace := &models.Namespace{


### PR DESCRIPTION
When creating a new namespace, the default experiment under that namespace should be named "Default".