### PR TITLE
Fix Python version incompatibilities with semantic versioning

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,10 @@ def get_data_files():
 
 def get_version():
     version = os.environ.get("VERSION")
-    return version.replace("-", "+", 1)
+    # Translate from semver to Python version specifier
+    # see https://semver.org
+    # see https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
+    return version.replace("-alpha.", "a", 1).replace("-beta.", "b", 1).replace("-rc.", "rc", 1).replace("-", "+", 1)
 
 
 def get_platform():


### PR DESCRIPTION
We recently released `0.4.0-rc.1`, but the Python wheels could not get uploaded to PyPI because the Python version specifier spec is incompatible with semantic versioning. This PR fixes that.

Once merged, the following tasks need to happen:
- [ ] backport to `release/0.4`
- [ ] create a new `0.4.0-rc.2` release