### PR TITLE
Use the correct logger in NamespaceCachedRepository

### DIFF
--- a/pkg/api/mlflow/dao/repositories/namespace_cached.go
+++ b/pkg/api/mlflow/dao/repositories/namespace_cached.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gofiber/fiber/v2/log"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/rotisserie/eris"
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao"


### PR DESCRIPTION
We were erroneously using the `fiber` logger instead of the `logrus` one in `NamespaceCachedRepository`.