### PR TITLE
Remove obsolete entries from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,6 @@ __debug_bin*
 fasttrackml.db*
 encrypted.db*
 
-# Imported integration tests
-tests/integration/python/*/*.src
-
 # Quick start
 outputs
 poetry.lock


### PR DESCRIPTION
These entries have become obsolete with #556 