### PR TITLE
Fix flaky Run flow integration test

### DIFF
--- a/tests/integration/golang/mlflow/namespace/flows/run_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/run_test.go
@@ -883,13 +883,13 @@ func (s *RunFlowTestSuite) getRunAndCompare(
 	s.Equal(expectedResponse.Run.Info.ExperimentID, resp.Run.Info.ExperimentID)
 	s.Equal(expectedResponse.Run.Info.LifecycleStage, resp.Run.Info.LifecycleStage)
 	if expectedResponse.Run.Data.Tags != nil {
-		s.Equal(expectedResponse.Run.Data.Tags, resp.Run.Data.Tags)
+		s.ElementsMatch(expectedResponse.Run.Data.Tags, resp.Run.Data.Tags)
 	}
 	if expectedResponse.Run.Data.Params != nil {
-		s.Equal(expectedResponse.Run.Data.Params, resp.Run.Data.Params)
+		s.ElementsMatch(expectedResponse.Run.Data.Params, resp.Run.Data.Params)
 	}
 	if expectedResponse.Run.Data.Metrics != nil {
-		s.Equal(expectedResponse.Run.Data.Metrics, resp.Run.Data.Metrics)
+		s.ElementsMatch(expectedResponse.Run.Data.Metrics, resp.Run.Data.Metrics)
 	}
 	return &resp
 }


### PR DESCRIPTION
This test assumed that the ordering of the tags, params, and metrics was guaranteed by the server, but it isn't. This PR changes the way we check for slice equality to allow for any order.