### PR TITLE
Create a new server instance per test in the integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         run: docker run --rm -v fml-integration-tests_go-cache:/cache -v /tmp/go-cache:/src alpine tar xf /src/go-build.tar -C /cache
 
       - name: Run Integration Tests
-        run: make service-test
+        run: make container-test
         env:
           DOCKER_BUILDKIT: 1
           FML_DATABASE_URI: ${{ matrix.database-uri }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,19 +57,6 @@
             ],
         },
         {
-            "name": "Launch server (supports integration tests)",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${workspaceFolder}/main.go",
-            "buildFlags": "-tags '${config:go.buildTags}'",
-            "args": [
-                "server",
-                "--database-uri",
-                "sqlite:///tmp/fasttrackml.db"
-            ],
-        },
-        {
             "name": "Launch database import (sqlite to pg)",
             "type": "go",
             "request": "launch",

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ python-lint: python-env ## check python code formatting.
 # Tests targets.
 #
 .PHONY: test
-test: test-go-unit service-test test-python-integration ## run all the tests.
+test: test-go-unit container-test test-python-integration ## run all the tests.
 
 .PHONY: test-go-unit
 test-go-unit: ## run go unit tests.
@@ -141,7 +141,7 @@ test-go-unit: ## run go unit tests.
 .PHONY: test-go-integration
 test-go-integration: ## run go integration tests.
 	@echo ">>> Running integration tests."
-	@go test -v -p 1 -count=1 -tags="integration" ./tests/integration/golang/...
+	@go test -v -p 1 -tags="$(GO_BUILDTAGS),integration" ./tests/integration/golang/...
 
 .PHONY: test-python-integration
 test-python-integration: ## run all the python integration tests.
@@ -159,31 +159,16 @@ test-python-integration-aim: ## run the Aim python integration tests.
 	@go run tests/integration/python/main.go -targets aim
 
 #
-# Service test targets.
+# Container test targets.
 #
-.PHONY: service-start
-service-start: ## start service in container.
-	@echo ">>> Starting up service container."
-	@COMPOSE_FILE=$(COMPOSE_FILE) COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-		docker-compose up -d service
-
-.PHONY: service-stop
-service-stop: ## stop service in container.
-	@echo ">>> Stopping service container."
-	@COMPOSE_FILE=$(COMPOSE_FILE) COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-		docker-compose stop service
-
-.PHONY: service-restart
-service-restart: service-stop service-start ## restart service in container.
-
-.PHONY: service-test
-service-test: service-restart ## run integration tests in container.
+.PHONY: container-test
+container-test: ## run integration tests in container.
 	@echo ">>> Running integration tests in container."
 	@COMPOSE_FILE=$(COMPOSE_FILE) COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-	    docker-compose run integration-tests
+		docker-compose run integration-tests
 
-.PHONY: service-clean
-service-clean: ## clean containers.
+.PHONY: container-clean
+container-clean: ## clean containers.
 	@echo ">>> Cleaning containers."
 	@COMPOSE_FILE=$(COMPOSE_FILE) COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
 		docker-compose down -v --remove-orphans

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,35 +1,4 @@
 services:
-  service:
-    image: golang:1.21
-    command: sh -c 'rm -rf /tmp/* && exec make run'
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
-      interval: 2s
-      timeout: 5s
-      start_period: 5m
-    volumes:
-      - ../../:/src
-      - go-cache:/cache
-      - tmp:/tmp
-    working_dir: /src
-    depends_on:
-      minio:
-        condition: service_healthy
-      google-storage:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-    environment:
-      GOCACHE: /cache/go-build
-      GOMODCACHE: /cache/go-mod
-      FML_LISTEN_ADDRESS: ":5000"
-      FML_LOG_LEVEL: debug
-      FML_DATABASE_URI: ${FML_DATABASE_URI:-postgres://postgres:postgres@postgres/postgres}
-      FML_S3_ENDPOINT_URI: http://minio:9000
-      FML_GS_ENDPOINT_URI: http://google-storage:4443/storage/v1/
-      AWS_ACCESS_KEY_ID: "user"
-      AWS_SECRET_ACCESS_KEY: "password"
-
   postgres:
     image: postgres:latest
     healthcheck:
@@ -67,7 +36,6 @@ services:
     volumes:
       - ../../:/src
       - go-cache:/cache
-      - tmp:/tmp
     working_dir: /src
     depends_on:
       minio:
@@ -76,12 +44,9 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-      service:
-        condition: service_healthy
     environment:
       GOCACHE: /cache/go-build
       GOMODCACHE: /cache/go-mod
-      FML_SERVICE_URI: http://service:5000
       FML_DATABASE_URI: ${FML_DATABASE_URI:-postgres://postgres:postgres@postgres/postgres}
       FML_S3_ENDPOINT_URI: http://minio:9000
       FML_GS_ENDPOINT_URI: http://google-storage:4443/storage/v1/
@@ -90,4 +55,3 @@ services:
 
 volumes:
   go-cache:
-  tmp:

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -5,18 +5,21 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"gorm.io/gorm"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
+	"github.com/G-Research/fasttrackml/pkg/api/mlflow/config"
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/dao/models"
 	"github.com/G-Research/fasttrackml/pkg/database"
+	"github.com/G-Research/fasttrackml/pkg/server"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/fixtures"
 )
 
-var db *gorm.DB
-
 type BaseTestSuite struct {
 	suite.Suite
+	server                      server.Server
+	db                          database.DBProvider
+	setupHooks                  []func()
+	tearDownHooks               []func()
 	AIMClient                   func() *HttpClient
 	MlflowClient                func() *HttpClient
 	AdminClient                 func() *HttpClient
@@ -35,8 +38,6 @@ type BaseTestSuite struct {
 	ResetOnSubTest              bool
 	SkipCreateDefaultNamespace  bool
 	SkipCreateDefaultExperiment bool
-	setupHooks                  []func()
-	tearDownHooks               []func()
 }
 
 func (s *BaseTestSuite) runSetupHooks() {
@@ -51,64 +52,18 @@ func (s *BaseTestSuite) runTearDownHooks() {
 	}
 }
 
-func (s *BaseTestSuite) setup() {
-	s.Require().Nil(s.NamespaceFixtures.TruncateTables())
-
-	if !s.SkipCreateDefaultNamespace {
-		var err error
-		s.DefaultNamespace, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
-			Code:                "default",
-			DefaultExperimentID: common.GetPointer(int32(0)),
-		})
-		s.Require().Nil(err)
-
-		if !s.SkipCreateDefaultExperiment {
-			s.DefaultExperiment, err = s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
-				Name:           "Default",
-				LifecycleStage: models.LifecycleStageActive,
-				NamespaceID:    s.DefaultNamespace.ID,
-			})
-			s.Require().Nil(err)
-
-			s.DefaultNamespace.DefaultExperimentID = s.DefaultExperiment.ID
-			_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), s.DefaultNamespace)
-			s.Require().Nil(err)
-		}
-	}
+func (s *BaseTestSuite) initDB() {
+	var err error
+	s.db, err = database.NewDBProvider(
+		GetDatabaseUri(),
+		1*time.Second,
+		20,
+	)
+	s.Require().Nil(err)
 }
 
-func (s *BaseTestSuite) tearDown() {
-	s.Require().Nil(s.NamespaceFixtures.TruncateTables())
-}
-
-func (s *BaseTestSuite) AddSetupHook(hook func()) {
-	s.setupHooks = append(s.setupHooks, hook)
-}
-
-func (s *BaseTestSuite) AddTearDownHook(hook func()) {
-	s.tearDownHooks = append([]func(){hook}, s.tearDownHooks...)
-}
-
-func (s *BaseTestSuite) SetupSuite() {
-	if db == nil {
-		instance, err := database.NewDBProvider(
-			GetDatabaseUri(),
-			1*time.Second,
-			20,
-		)
-		s.Require().Nil(err)
-		db = instance.GormDB()
-	}
-
-	s.AIMClient = func() *HttpClient {
-		return NewAimApiClient(GetServiceUri())
-	}
-	s.MlflowClient = func() *HttpClient {
-		return NewMlflowApiClient(GetServiceUri())
-	}
-	s.AdminClient = func() *HttpClient {
-		return NewAdminApiClient(GetServiceUri())
-	}
+func (s *BaseTestSuite) initFixtures() {
+	db := s.db.GormDB()
 
 	appFixtures, err := fixtures.NewAppFixtures(db)
 	s.Require().Nil(err)
@@ -149,9 +104,91 @@ func (s *BaseTestSuite) SetupSuite() {
 	contextFixtures, err := fixtures.NewContextFixtures(db)
 	s.Require().Nil(err)
 	s.ContextFixtures = contextFixtures
+}
 
-	s.AddSetupHook(s.setup)
-	s.AddTearDownHook(s.tearDown)
+func (s *BaseTestSuite) closeDB() {
+	s.Require().Nil(s.db.Close())
+}
+
+func (s *BaseTestSuite) startServer() {
+	var err error
+	s.server, err = server.NewServer(context.Background(), &config.ServiceConfig{
+		DatabaseURI:           s.db.Dsn(),
+		DatabasePoolMax:       10,
+		DatabaseSlowThreshold: 1 * time.Second,
+		DatabaseMigrate:       true,
+		DefaultArtifactRoot:   s.T().TempDir(),
+		S3EndpointURI:         GetS3EndpointUri(),
+		GSEndpointURI:         GetGSEndpointUri(),
+	})
+	s.Require().Nil(err)
+
+	s.AIMClient = func() *HttpClient {
+		return NewAimApiClient(s.server)
+	}
+	s.MlflowClient = func() *HttpClient {
+		return NewMlflowApiClient(s.server)
+	}
+	s.AdminClient = func() *HttpClient {
+		return NewAdminApiClient(s.server)
+	}
+}
+
+func (s *BaseTestSuite) stopServer() {
+	s.Require().Nil(s.server.ShutdownWithTimeout(5 * time.Second))
+}
+
+func (s *BaseTestSuite) setupDatabase() {
+	s.resetDatabase()
+
+	if !s.SkipCreateDefaultNamespace {
+		var err error
+		s.DefaultNamespace, err = s.NamespaceFixtures.CreateNamespace(context.Background(), &models.Namespace{
+			ID:                  1,
+			Code:                "default",
+			DefaultExperimentID: common.GetPointer(int32(0)),
+		})
+		s.Require().Nil(err)
+
+		if !s.SkipCreateDefaultExperiment {
+			s.DefaultExperiment, err = s.ExperimentFixtures.CreateExperiment(context.Background(), &models.Experiment{
+				ID:             common.GetPointer[int32](0),
+				Name:           "Default",
+				LifecycleStage: models.LifecycleStageActive,
+				NamespaceID:    s.DefaultNamespace.ID,
+			})
+			s.Require().Nil(err)
+
+			s.DefaultNamespace.DefaultExperimentID = s.DefaultExperiment.ID
+			_, err = s.NamespaceFixtures.UpdateNamespace(context.Background(), s.DefaultNamespace)
+			s.Require().Nil(err)
+		}
+	}
+}
+
+func (s *BaseTestSuite) resetDatabase() {
+	s.Require().Nil(s.NamespaceFixtures.TruncateTables())
+}
+
+func (s *BaseTestSuite) AddSetupHook(hook func()) {
+	s.setupHooks = append(s.setupHooks, hook)
+}
+
+func (s *BaseTestSuite) AddTearDownHook(hook func()) {
+	s.tearDownHooks = append([]func(){hook}, s.tearDownHooks...)
+}
+
+func (s *BaseTestSuite) SetupSuite() {
+	s.initDB()
+	s.initFixtures()
+	s.AddSetupHook(s.startServer)
+	s.AddSetupHook(s.setupDatabase)
+	s.AddTearDownHook(s.resetDatabase)
+	s.AddTearDownHook(s.stopServer)
+}
+
+func (s *BaseTestSuite) TearDownSuite() {
+	s.closeDB()
 }
 
 func (s *BaseTestSuite) SetupTest() {


### PR DESCRIPTION
This PR changes our integration tests to have a new unique server instance per test, allowing us to debug end-to-end and simplifying the setup.