### PR TITLE
Hook up logging in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ test: test-go-unit container-test test-python-integration ## run all the tests.
 .PHONY: test-go-unit
 test-go-unit: ## run go unit tests.
 	@echo ">>> Running unit tests."
-	@go test -v ./...
+	@go test ./...
 
 .PHONY: test-go-integration
 test-go-integration: ## run go integration tests.
 	@echo ">>> Running integration tests."
-	@go test -v -p 1 -tags="$(GO_BUILDTAGS),integration" ./tests/integration/golang/...
+	@go test -p 1 -tags="$(GO_BUILDTAGS),integration" ./tests/integration/golang/...
 
 .PHONY: test-python-integration
 test-python-integration: ## run all the python integration tests.

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     environment:
       GOCACHE: /cache/go-build
       GOMODCACHE: /cache/go-mod
+      FML_LOG_LEVEL: ${FML_LOG_LEVEL:-fatal}
       FML_DATABASE_URI: ${FML_DATABASE_URI:-postgres://postgres:postgres@postgres/postgres}
       FML_S3_ENDPOINT_URI: http://minio:9000
       FML_GS_ENDPOINT_URI: http://google-storage:4443/storage/v1/

--- a/tests/integration/golang/helpers/env.go
+++ b/tests/integration/golang/helpers/env.go
@@ -2,6 +2,14 @@ package helpers
 
 import "os"
 
+func GetLogLevel() string {
+	level, ok := os.LookupEnv("FML_LOG_LEVEL")
+	if ok {
+		return level
+	}
+	return "info"
+}
+
 func GetDatabaseUri() string {
 	uri, ok := os.LookupEnv("FML_DATABASE_URI")
 	if ok {

--- a/tests/integration/golang/helpers/test.go
+++ b/tests/integration/golang/helpers/test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/common"
@@ -50,6 +51,13 @@ func (s *BaseTestSuite) runTearDownHooks() {
 	for _, hook := range s.tearDownHooks {
 		hook()
 	}
+}
+
+func (s *BaseTestSuite) initLogger() {
+	levelString := GetLogLevel()
+	level, err := logrus.ParseLevel(levelString)
+	s.Require().Nil(err)
+	logrus.SetLevel(level)
 }
 
 func (s *BaseTestSuite) initDB() {
@@ -179,6 +187,7 @@ func (s *BaseTestSuite) AddTearDownHook(hook func()) {
 }
 
 func (s *BaseTestSuite) SetupSuite() {
+	s.initLogger()
 	s.initDB()
 	s.initFixtures()
 	s.AddSetupHook(s.startServer)


### PR DESCRIPTION
This PR ensures that logging is configured in our integration tests using the expected `FML_LOG_LEVEL` environment variable. The `Makefile` targets are also updated so that the debug logs are only displayed when a test fails.