### PR TITLE
Remove integration build tag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,7 @@ run:
   tests: true
 
   # creators of build tags, all linters use it. Default is empty creators.
-  build-tags:
-    - integration
+  build-tags: []
 
   # which dirs to skip: they won't be analyzed;
   # can use regexp here: generated.*, regexp is applied on full path;

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    // Please keep the content of go.buildTags identical to the content of the authoritative file .go-build-tags (but add integration tests tag here)
-    "go.buildTags": "netgo,osusergo,sqlite_foreign_keys,sqlite_math_functions,sqlite_omit_load_extension,sqlite_unlock_notify,sqlite_vacuum_incr,integration",
+    // Please keep the content of go.buildTags identical to the content of the authoritative file .go-build-tags
+    "go.buildTags": "netgo,osusergo,sqlite_foreign_keys,sqlite_math_functions,sqlite_omit_load_extension,sqlite_unlock_notify,sqlite_vacuum_incr",
     "gopls": {
         "formatting.local": "github.com/G-Research/fasttrackml",
         "formatting.gofumpt": true

--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ test: test-go-unit container-test test-python-integration ## run all the tests.
 .PHONY: test-go-unit
 test-go-unit: ## run go unit tests.
 	@echo ">>> Running unit tests."
-	@go test ./...
+	@go test -tags="$(GO_BUILDTAGS)" ./pkg/...
 
 .PHONY: test-go-integration
 test-go-integration: ## run go integration tests.
 	@echo ">>> Running integration tests."
-	@go test -tags="$(GO_BUILDTAGS),integration" ./tests/integration/golang/...
+	@go test -tags="$(GO_BUILDTAGS)" ./tests/integration/golang/...
 
 .PHONY: test-python-integration
 test-python-integration: ## run all the python integration tests.

--- a/tests/integration/golang/admin/namespace/create_test.go
+++ b/tests/integration/golang/admin/namespace/create_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package namespace
 
 import (

--- a/tests/integration/golang/admin/namespace/delete_test.go
+++ b/tests/integration/golang/admin/namespace/delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package namespace
 
 import (

--- a/tests/integration/golang/admin/namespace/update_test.go
+++ b/tests/integration/golang/admin/namespace/update_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package namespace
 
 import (

--- a/tests/integration/golang/aim/app/create_app_test.go
+++ b/tests/integration/golang/aim/app/create_app_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/app/delete_app_test.go
+++ b/tests/integration/golang/aim/app/delete_app_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/app/get_app_test.go
+++ b/tests/integration/golang/aim/app/get_app_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/app/update_app_test.go
+++ b/tests/integration/golang/aim/app/update_app_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/delete_dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/experiment/delete_test.go
+++ b/tests/integration/golang/aim/experiment/delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_activity_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_runs_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/aim/experiment/get_experiment_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiment_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/aim/experiment/get_experiments_test.go
+++ b/tests/integration/golang/aim/experiment/get_experiments_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/aim/metric/search_aligned_test.go
+++ b/tests/integration/golang/aim/metric/search_aligned_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/metric/search_test.go
+++ b/tests/integration/golang/aim/metric/search_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/namespace/flows/app_test.go
+++ b/tests/integration/golang/aim/namespace/flows/app_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/aim/namespace/flows/dashboard_test.go
+++ b/tests/integration/golang/aim/namespace/flows/dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/aim/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/aim/namespace/flows/experiment_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/aim/namespace/flows/metric_test.go
+++ b/tests/integration/golang/aim/namespace/flows/metric_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/aim/namespace/flows/project_test.go
+++ b/tests/integration/golang/aim/namespace/flows/project_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/aim/namespace/flows/run_test.go
+++ b/tests/integration/golang/aim/namespace/flows/run_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/aim/namespace/namespace_test.go
+++ b/tests/integration/golang/aim/namespace/namespace_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package namespace
 
 import (

--- a/tests/integration/golang/aim/project/get_project_activity_test.go
+++ b/tests/integration/golang/aim/project/get_project_activity_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/project/get_project_params_test.go
+++ b/tests/integration/golang/aim/project/get_project_params_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/project/get_project_status_test.go
+++ b/tests/integration/golang/aim/project/get_project_status_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/project/get_project_test.go
+++ b/tests/integration/golang/aim/project/get_project_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/archive_batch_test.go
+++ b/tests/integration/golang/aim/run/archive_batch_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/delete_batch_test.go
+++ b/tests/integration/golang/aim/run/delete_batch_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/delete_test.go
+++ b/tests/integration/golang/aim/run/delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/get_run_metrics_test.go
+++ b/tests/integration/golang/aim/run/get_run_metrics_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/aim/run/update_run_test.go
+++ b/tests/integration/golang/aim/run/update_run_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/database/import_test.go
+++ b/tests/integration/golang/database/import_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package database
 
 import (

--- a/tests/integration/golang/database/migrate_test.go
+++ b/tests/integration/golang/database/migrate_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package database
 
 import (

--- a/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_gs_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package artifact
 
 import (

--- a/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_local_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package artifact
 
 import (

--- a/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/get_artifact_s3_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package artifact
 
 import (

--- a/tests/integration/golang/mlflow/artifact/list_gs_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_gs_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package artifact
 
 import (

--- a/tests/integration/golang/mlflow/artifact/list_local_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_local_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package artifact
 
 import (

--- a/tests/integration/golang/mlflow/artifact/list_s3_test.go
+++ b/tests/integration/golang/mlflow/artifact/list_s3_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package artifact
 
 import (

--- a/tests/integration/golang/mlflow/experiment/create_test.go
+++ b/tests/integration/golang/mlflow/experiment/create_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/delete_test.go
+++ b/tests/integration/golang/mlflow/experiment/delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/get_by_name_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_by_name_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/get_test.go
+++ b/tests/integration/golang/mlflow/experiment/get_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/restore_test.go
+++ b/tests/integration/golang/mlflow/experiment/restore_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/search_test.go
+++ b/tests/integration/golang/mlflow/experiment/search_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
+++ b/tests/integration/golang/mlflow/experiment/set_experiment_tag_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/experiment/update_test.go
+++ b/tests/integration/golang/mlflow/experiment/update_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package experiment
 
 import (

--- a/tests/integration/golang/mlflow/metric/get_histories_test.go
+++ b/tests/integration/golang/mlflow/metric/get_histories_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package metric
 
 import (

--- a/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_bulk_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package metric
 
 import (

--- a/tests/integration/golang/mlflow/metric/get_history_test.go
+++ b/tests/integration/golang/mlflow/metric/get_history_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package metric
 
 import (

--- a/tests/integration/golang/mlflow/namespace/flows/artifact_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/artifact_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/experiment_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/mlflow/namespace/flows/metric_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/metric_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/mlflow/namespace/flows/run_test.go
+++ b/tests/integration/golang/mlflow/namespace/flows/run_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package flows
 
 import (

--- a/tests/integration/golang/mlflow/namespace/namespace_test.go
+++ b/tests/integration/golang/mlflow/namespace/namespace_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package namespace
 
 import (

--- a/tests/integration/golang/mlflow/run/create_test.go
+++ b/tests/integration/golang/mlflow/run/create_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/delete_tag_test.go
+++ b/tests/integration/golang/mlflow/run/delete_tag_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/delete_test.go
+++ b/tests/integration/golang/mlflow/run/delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/get_test.go
+++ b/tests/integration/golang/mlflow/run/get_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/log_batch_test.go
+++ b/tests/integration/golang/mlflow/run/log_batch_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/log_metric_test.go
+++ b/tests/integration/golang/mlflow/run/log_metric_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/log_parameter_test.go
+++ b/tests/integration/golang/mlflow/run/log_parameter_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/restore_test.go
+++ b/tests/integration/golang/mlflow/run/restore_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/search_test.go
+++ b/tests/integration/golang/mlflow/run/search_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/set_tag_test.go
+++ b/tests/integration/golang/mlflow/run/set_tag_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (

--- a/tests/integration/golang/mlflow/run/update_test.go
+++ b/tests/integration/golang/mlflow/run/update_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package run
 
 import (


### PR DESCRIPTION
This PR removes the `integration` build tag entirely as they don't seem necessary anymore.