### PR TITLE
Revert the temporary solution of disabling cache for integration tests

### DIFF
--- a/pkg/api/mlflow/dao/repositories/mock_namespace_repository_provider.go
+++ b/pkg/api/mlflow/dao/repositories/mock_namespace_repository_provider.go
@@ -42,25 +42,25 @@ func (_m *MockNamespaceRepositoryProvider) Delete(ctx context.Context, namespace
 	return r0
 }
 
-// GetByCode provides a mock function with given fields: ctx, noCache, code
-func (_m *MockNamespaceRepositoryProvider) GetByCode(ctx context.Context, noCache bool, code string) (*models.Namespace, error) {
-	ret := _m.Called(ctx, noCache, code)
+// GetByCode provides a mock function with given fields: ctx, code
+func (_m *MockNamespaceRepositoryProvider) GetByCode(ctx context.Context, code string) (*models.Namespace, error) {
+	ret := _m.Called(ctx, code)
 
 	var r0 *models.Namespace
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, bool, string) (*models.Namespace, error)); ok {
-		return rf(ctx, noCache, code)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.Namespace, error)); ok {
+		return rf(ctx, code)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, bool, string) *models.Namespace); ok {
-		r0 = rf(ctx, noCache, code)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *models.Namespace); ok {
+		r0 = rf(ctx, code)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Namespace)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, bool, string) error); ok {
-		r1 = rf(ctx, noCache, code)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, code)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/api/mlflow/dao/repositories/namespace.go
+++ b/pkg/api/mlflow/dao/repositories/namespace.go
@@ -19,7 +19,7 @@ type NamespaceRepositoryProvider interface {
 	// Delete removes a namespace and it's associated experiments by its ID.
 	Delete(ctx context.Context, namespace *models.Namespace) error
 	// GetByCode returns namespace by its Code.
-	GetByCode(ctx context.Context, noCache bool, code string) (*models.Namespace, error)
+	GetByCode(ctx context.Context, code string) (*models.Namespace, error)
 	// GetByID returns namespace by its ID.
 	GetByID(ctx context.Context, id uint) (*models.Namespace, error)
 	// List returns all namespaces.
@@ -63,7 +63,7 @@ func (r NamespaceRepository) Delete(ctx context.Context, namespace *models.Names
 }
 
 // GetByCode returns namespace by its Code.
-func (r NamespaceRepository) GetByCode(ctx context.Context, _ bool, code string) (*models.Namespace, error) {
+func (r NamespaceRepository) GetByCode(ctx context.Context, code string) (*models.Namespace, error) {
 	var namespace models.Namespace
 	if err := r.db.WithContext(ctx).Where(
 		"code = ?", code,

--- a/pkg/api/mlflow/dao/repositories/namespace_cached.go
+++ b/pkg/api/mlflow/dao/repositories/namespace_cached.go
@@ -105,19 +105,9 @@ func (r NamespaceCachedRepository) Update(ctx context.Context, namespace *models
 
 // GetByCode returns namespace by its Code.
 func (r NamespaceCachedRepository) GetByCode(
-	ctx context.Context, noCache bool, code string,
+	ctx context.Context, code string,
 ) (*models.Namespace, error) {
-	// TODO:dsuhinin - it is temporary solution for integration tests.
-	// Right now we have to disable cache, because in integration tests we directly work with database.
-	// It leads that cache state and database state is out of sync and different tests could just fail
-	if !noCache {
-		result, ok := r.cache.Get(code)
-		if ok {
-			return &result, nil
-		}
-	}
-
-	namespace, err := r.namespaceRepository.GetByCode(ctx, noCache, code)
+	namespace, err := r.namespaceRepository.GetByCode(ctx, code)
 	if err != nil {
 		return nil, eris.Wrapf(err, "error getting cached namespace by code: %s", code)
 	}

--- a/pkg/common/middleware/namespace/namespace.go
+++ b/pkg/common/middleware/namespace/namespace.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -27,18 +26,14 @@ var namespaceRegexp = regexp.MustCompile(`^/ns/([^/]+)/`)
 // New creates new Middleware instance
 func New(namespaceRepository repositories.NamespaceRepositoryProvider) fiber.Handler {
 	return func(c *fiber.Ctx) (err error) {
-		noCache, err := strconv.ParseBool(string(c.Request().Header.Peek("no-cache")))
-		if err != nil {
-			noCache = false
-		}
-		log.Debugf("checking namespace for path: %s. no-cache: %t", c.Path(), noCache)
+		log.Debugf("checking namespace for path: %s", c.Path())
 		// if namespace exists in the request then try to process it, otherwise fallback to default namespace.
 		namespaceCode := defaultNamespaceCode
 		if matches := namespaceRegexp.FindStringSubmatch(c.Path()); matches != nil {
 			namespaceCode = strings.Clone(matches[1])
 			c.Path(strings.TrimPrefix(c.Path(), fmt.Sprintf("/ns/%s", namespaceCode)))
 		}
-		namespace, err := namespaceRepository.GetByCode(c.Context(), noCache, namespaceCode)
+		namespace, err := namespaceRepository.GetByCode(c.Context(), namespaceCode)
 		if err != nil {
 			return c.JSON(api.NewInternalError("error getting namespace with code: %s", namespaceCode))
 		}

--- a/tests/integration/golang/helpers/client.go
+++ b/tests/integration/golang/helpers/client.go
@@ -175,9 +175,6 @@ func (c *HttpClient) DoRequest(uri string, values ...any) error {
 			req.Header.Set(key, value)
 		}
 	}
-	// TODO:dsuhinin - right now set `no-cache` for all the requests to avoid any
-	// problem related to namespace caching logic. Remove it a bit later.
-	req.Header.Set("no-cache", "true")
 
 	// 7. send request data.
 	resp, err := c.server.Test(req, 60000)


### PR DESCRIPTION
This PR reverts our temporary solution that disabled caching in our integration tests now that we use per-test embedded server instances.