### PR TITLE
Fix experiment name not being displayed in Aim UI run views

### DIFF
--- a/pkg/api/aim/runs.go
+++ b/pkg/api/aim/runs.go
@@ -54,7 +54,7 @@ func GetRunInfo(c *fiber.Ctx) error {
 		InnerJoins(
 			"Experiment",
 			database.DB.Select(
-				"ID",
+				"ID", "Name",
 			).Where(
 				&models.Experiment{NamespaceID: ns.ID},
 			),
@@ -257,7 +257,7 @@ func GetRunsActive(c *fiber.Ctx) error {
 		InnerJoins(
 			"Experiment",
 			database.DB.Select(
-				"ID",
+				"ID", "Name",
 			).Where(
 				&models.Experiment{NamespaceID: ns.ID},
 			),
@@ -415,7 +415,7 @@ func SearchRuns(c *fiber.Ctx) error {
 		InnerJoins(
 			"Experiment",
 			database.DB.Select(
-				"ID",
+				"ID", "Name",
 			).Where(
 				&models.Experiment{NamespaceID: ns.ID},
 			),
@@ -623,7 +623,7 @@ func SearchMetrics(c *fiber.Ctx) error {
 		InnerJoins(
 			"Experiment",
 			database.DB.Select(
-				"ID",
+				"ID", "Name",
 			).Where(&models.Experiment{NamespaceID: ns.ID}),
 		).
 		Preload("Params").

--- a/tests/integration/golang/aim/run/get_run_info_test.go
+++ b/tests/integration/golang/aim/run/get_run_info_test.go
@@ -48,6 +48,7 @@ func (s *GetRunInfoTestSuite) Test_Ok() {
 			)
 			s.Equal(s.run.Name, resp.Props.Name)
 			s.Equal(fmt.Sprintf("%v", s.run.ExperimentID), resp.Props.Experiment.ID)
+			s.Equal(s.run.Experiment.Name, resp.Props.Experiment.Name)
 			s.Equal(float64(s.run.StartTime.Int64)/1000, resp.Props.CreationTime)
 			s.Equal(float64(s.run.EndTime.Int64)/1000, resp.Props.EndTime)
 			expectedTags := make(map[string]string, len(s.run.Tags))

--- a/tests/integration/golang/aim/run/get_runs_active_test.go
+++ b/tests/integration/golang/aim/run/get_runs_active_test.go
@@ -78,6 +78,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 			for _, run := range s.runs {
 				respNameKey := fmt.Sprintf("%v.props.name", run.ID)
 				expIdKey := fmt.Sprintf("%v.props.experiment.id", run.ID)
+				expNameKey := fmt.Sprintf("%v.props.experiment.name", run.ID)
 				startTimeKey := fmt.Sprintf("%v.props.creation_time", run.ID)
 				endTimeKey := fmt.Sprintf("%v.props.end_time", run.ID)
 				activeKey := fmt.Sprintf("%v.props.active", run.ID)
@@ -86,6 +87,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 					models.LifecycleStageActive {
 					s.Equal(run.Name, decodedData[respNameKey])
 					s.Equal(fmt.Sprintf("%v", run.ExperimentID), decodedData[expIdKey])
+					s.Equal(run.Experiment.Name, decodedData[expNameKey])
 					s.Equal(run.Status == models.StatusRunning, decodedData[activeKey])
 					s.Equal(false, decodedData[archivedKey])
 					s.Equal(float64(run.StartTime.Int64)/1000, decodedData[startTimeKey])
@@ -94,6 +96,7 @@ func (s *GetRunsActiveTestSuite) Test_Ok() {
 				} else {
 					s.Nil(decodedData[respNameKey])
 					s.Nil(decodedData[expIdKey])
+					s.Nil(decodedData[expNameKey])
 					s.Nil(decodedData[activeKey])
 					s.Nil(decodedData[archivedKey])
 					s.Nil(decodedData[startTimeKey])

--- a/tests/integration/golang/aim/run/search_test.go
+++ b/tests/integration/golang/aim/run/search_test.go
@@ -61,6 +61,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri1",
 		LifecycleStage: models.LifecycleStageActive,
 	})
+	run1.Experiment = *experiment
 	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
@@ -104,6 +105,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri2",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
+	run2.Experiment = *experiment
 	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
@@ -147,6 +149,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri3",
 		LifecycleStage: models.LifecycleStageActive,
 	})
+	run3.Experiment = *experiment2
 	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
@@ -190,6 +193,7 @@ func (s *SearchTestSuite) Test_Ok() {
 		ArtifactURI:    "artifact_uri4",
 		LifecycleStage: models.LifecycleStageDeleted,
 	})
+	run4.Experiment = *experiment2
 	s.Require().Nil(err)
 	_, err = s.TagFixtures.CreateTag(context.Background(), &models.Tag{
 		Key:   "mlflow.runName",
@@ -774,6 +778,7 @@ func (s *SearchTestSuite) Test_Ok() {
 			for _, run := range runs {
 				respNameKey := fmt.Sprintf("%v.props.name", run.ID)
 				expIdKey := fmt.Sprintf("%v.props.experiment.id", run.ID)
+				expNameKey := fmt.Sprintf("%v.props.experiment.name", run.ID)
 				startTimeKey := fmt.Sprintf("%v.props.creation_time", run.ID)
 				endTimeKey := fmt.Sprintf("%v.props.end_time", run.ID)
 				activeKey := fmt.Sprintf("%v.props.active", run.ID)
@@ -785,6 +790,7 @@ func (s *SearchTestSuite) Test_Ok() {
 					s.Equal(
 						fmt.Sprintf("%v", run.ExperimentID),
 						decodedData[expIdKey])
+					s.Equal(run.Experiment.Name, decodedData[expNameKey])
 					s.Equal(
 						run.Status == models.StatusRunning,
 						decodedData[activeKey])

--- a/tests/integration/golang/fixtures/run.go
+++ b/tests/integration/golang/fixtures/run.go
@@ -98,6 +98,7 @@ func (f RunFixtures) CreateExampleRuns(
 		if err != nil {
 			return nil, err
 		}
+		run.Experiment = *exp
 		tag := models.Tag{
 			Key:   "my tag key",
 			Value: "my tag value",


### PR DESCRIPTION
Our latest release inadvertently removed experiment names from the all Aim UI run views. This PR fixes it and adds a few additional assertions to our integration tests.