### PR TITLE
Improve the response types used for apps and dashboards in integration tests

### DIFF
--- a/pkg/api/aim/response/app.go
+++ b/pkg/api/aim/response/app.go
@@ -1,10 +1,14 @@
 package response
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // App represents the response json in App endpoints
 type App struct {
-	ID        string    `json:"id"`
+	ID        uuid.UUID `json:"id"`
 	Type      string    `json:"type"`
 	State     AppState  `json:"state"`
 	CreatedAt time.Time `json:"created_at"`

--- a/pkg/api/aim/response/dashboard.go
+++ b/pkg/api/aim/response/dashboard.go
@@ -8,11 +8,11 @@ import (
 
 // Dashboard represents the response json in Dashboard endpoints
 type Dashboard struct {
-	ID          string    `json:"id"`
+	ID          uuid.UUID `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
 	AppID       uuid.UUID `json:"app_id"`
-	Type        string    `json:"app_type"`
+	AppType     string    `json:"app_type"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }

--- a/tests/integration/golang/aim/app/get_apps_test.go
+++ b/tests/integration/golang/aim/app/get_apps_test.go
@@ -46,7 +46,7 @@ func (s *GetAppsTestSuite) Test_Ok() {
 			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/apps"))
 			s.Equal(tt.expectedAppCount, len(resp))
 			for idx := 0; idx < tt.expectedAppCount; idx++ {
-				s.Equal(apps[idx].ID.String(), resp[idx].ID)
+				s.Equal(apps[idx].ID, resp[idx].ID)
 				s.Equal(apps[idx].Type, resp[idx].Type)
 				s.Equal(apps[idx].State, database.AppState(resp[idx].State))
 				s.NotEmpty(resp[idx].CreatedAt)

--- a/tests/integration/golang/aim/dashboard/create_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/create_dashboard_test.go
@@ -68,7 +68,7 @@ func (s *CreateDashboardTestSuite) Test_Ok() {
 			s.Equal(tt.requestBody.Description, resp.Description)
 			s.Equal(dashboards[0].Name, resp.Name)
 			s.Equal(dashboards[0].Description, resp.Description)
-			s.Equal(dashboards[0].ID.String(), resp.ID)
+			s.Equal(dashboards[0].ID, resp.ID)
 			s.Equal(dashboards[0].AppID, &resp.AppID)
 			s.NotEmpty(resp.ID)
 		})

--- a/tests/integration/golang/aim/dashboard/get_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboard_test.go
@@ -46,10 +46,11 @@ func (s *GetDashboardTestSuite) Test_Ok() {
 	})
 	s.Require().Nil(err)
 
-	var resp database.Dashboard
+	var resp response.Dashboard
 	s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/dashboards/%s", dashboard.ID))
 	s.Equal(dashboard.ID, resp.ID)
-	s.Equal(&app.ID, resp.AppID)
+	s.Equal(app.ID, resp.AppID)
+	s.Equal(app.Type, resp.AppType)
 	s.Equal(dashboard.Name, resp.Name)
 	s.Equal(dashboard.Description, resp.Description)
 	s.NotEmpty(resp.CreatedAt)

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -62,8 +62,9 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/dashboards"))
 			s.Equal(tt.expectedDashboardCount, len(resp))
 			for idx := 0; idx < tt.expectedDashboardCount; idx++ {
-				s.Equal(dashboards[idx].ID.String(), resp[idx].ID)
+				s.Equal(dashboards[idx].ID, resp[idx].ID)
 				s.Equal(app.ID, resp[idx].AppID)
+				s.Equal(app.Type, resp[idx].AppType)
 				s.Equal(dashboards[idx].Name, resp[idx].Name)
 				s.Equal(dashboards[idx].Description, resp[idx].Description)
 				s.NotEmpty(resp[idx].CreatedAt)

--- a/tests/integration/golang/aim/dashboard/update_dashboard_test.go
+++ b/tests/integration/golang/aim/dashboard/update_dashboard_test.go
@@ -91,7 +91,7 @@ func (s *UpdateDashboardTestSuite) Test_Ok() {
 			s.Require().Nil(err)
 			s.Equal(tt.requestBody.Name, resp.Name)
 			s.Equal(tt.requestBody.Description, resp.Description)
-			s.Equal((dashboard.ID).String(), resp.ID)
+			s.Equal(dashboard.ID, resp.ID)
 			s.Equal(tt.requestBody.Name, actualDashboard.Name)
 			s.Equal(tt.requestBody.Description, actualDashboard.Description)
 		})

--- a/tests/integration/golang/aim/namespace/flows/app_test.go
+++ b/tests/integration/golang/aim/namespace/flows/app_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/request"
@@ -156,7 +157,7 @@ func (s *AppFlowTestSuite) testAppFlow(
 	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 }
 
-func (s *AppFlowTestSuite) deleteAppAndCompare(namespaceCode string, appID string) {
+func (s *AppFlowTestSuite) deleteAppAndCompare(namespaceCode string, appID uuid.UUID) {
 	client := s.AIMClient()
 	appResp := response.App{}
 	s.Require().Nil(
@@ -173,7 +174,7 @@ func (s *AppFlowTestSuite) deleteAppAndCompare(namespaceCode string, appID strin
 	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
-func (s *AppFlowTestSuite) updateAppAndCompare(namespaceCode string, appID string) {
+func (s *AppFlowTestSuite) updateAppAndCompare(namespaceCode string, appID uuid.UUID) {
 	client := s.AIMClient()
 	appResp := response.App{}
 	s.Require().Nil(
@@ -198,7 +199,7 @@ func (s *AppFlowTestSuite) updateAppAndCompare(namespaceCode string, appID strin
 	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
-func (s *AppFlowTestSuite) getAppAndCompare(namespaceCode string, appID string) response.App {
+func (s *AppFlowTestSuite) getAppAndCompare(namespaceCode string, appID uuid.UUID) response.App {
 	appResp := response.App{}
 	client := s.AIMClient()
 	s.Require().Nil(
@@ -233,7 +234,7 @@ func (s *AppFlowTestSuite) getApps(namespaceCode string) []response.App {
 	return resp
 }
 
-func (s *AppFlowTestSuite) createAppAndCompare(namespace string, req *request.CreateApp) string {
+func (s *AppFlowTestSuite) createAppAndCompare(namespace string, req *request.CreateApp) uuid.UUID {
 	var resp response.App
 	s.Require().Nil(
 		s.AIMClient().WithMethod(

--- a/tests/integration/golang/aim/namespace/flows/dashboard_test.go
+++ b/tests/integration/golang/aim/namespace/flows/dashboard_test.go
@@ -92,13 +92,13 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 	dashboard1ID := s.createDashboard(namespace1Code, &request.CreateDashboard{
 		Name:        "dashboard1-name",
 		Description: "dashboard1-description",
-		AppID:       uuid.MustParse(app1ID),
+		AppID:       app1ID,
 	})
 
 	dashboard2ID := s.createDashboard(namespace2Code, &request.CreateDashboard{
 		Name:        "dashboard2-name",
 		Description: "dashboard2-description",
-		AppID:       uuid.MustParse(app2ID),
+		AppID:       app2ID,
 	})
 
 	// test `GET /dashboards` endpoint with namespace 1
@@ -168,7 +168,9 @@ func (s *DashboardFlowTestSuite) testDashboardFlow(
 	s.Equal(fiber.ErrNotFound.Code, client.GetStatusCode())
 }
 
-func (s *DashboardFlowTestSuite) deleteDashboardAndCompare(namespaceCode string, dashboardID string) {
+func (s *DashboardFlowTestSuite) deleteDashboardAndCompare(
+	namespaceCode string, dashboardID uuid.UUID,
+) {
 	client := s.AIMClient()
 	dashboardResp := response.Dashboard{}
 	s.Require().Nil(
@@ -185,7 +187,9 @@ func (s *DashboardFlowTestSuite) deleteDashboardAndCompare(namespaceCode string,
 	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
-func (s *DashboardFlowTestSuite) updateDashboardAndCompare(namespaceCode string, dashboardID string) {
+func (s *DashboardFlowTestSuite) updateDashboardAndCompare(
+	namespaceCode string, dashboardID uuid.UUID,
+) {
 	client := s.AIMClient()
 	dashboardResp := response.Dashboard{}
 	s.Require().Nil(
@@ -208,7 +212,9 @@ func (s *DashboardFlowTestSuite) updateDashboardAndCompare(namespaceCode string,
 	s.Equal(fiber.StatusOK, client.GetStatusCode())
 }
 
-func (s *DashboardFlowTestSuite) getDashboardAndCompare(namespaceCode string, dashboardID string) response.Dashboard {
+func (s *DashboardFlowTestSuite) getDashboardAndCompare(
+	namespaceCode string, dashboardID uuid.UUID,
+) response.Dashboard {
 	dashboardResp := response.Dashboard{}
 	client := s.AIMClient()
 	s.Require().Nil(
@@ -243,7 +249,7 @@ func (s *DashboardFlowTestSuite) getDashboards(namespaceCode string) []response.
 	return resp
 }
 
-func (s *DashboardFlowTestSuite) createApp(namespace string, req *request.CreateApp) string {
+func (s *DashboardFlowTestSuite) createApp(namespace string, req *request.CreateApp) uuid.UUID {
 	var resp response.App
 	s.Require().Nil(
 		s.AIMClient().WithMethod(
@@ -261,7 +267,7 @@ func (s *DashboardFlowTestSuite) createApp(namespace string, req *request.Create
 	return resp.ID
 }
 
-func (s *DashboardFlowTestSuite) createDashboard(namespace string, req *request.CreateDashboard) string {
+func (s *DashboardFlowTestSuite) createDashboard(namespace string, req *request.CreateDashboard) uuid.UUID {
 	var resp response.Dashboard
 	s.Require().Nil(
 		s.AIMClient().WithMethod(


### PR DESCRIPTION
This PR changes the response types used for apps and dashboards to use proper UUID types. It also renames the `app_type` field and checks it in the various dashboard tests.