### PR TITLE
List most recent bookmarks on top

### DIFF
--- a/pkg/api/aim/dashboards.go
+++ b/pkg/api/aim/dashboards.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/G-Research/fasttrackml/pkg/api/mlflow/api"
 	"github.com/G-Research/fasttrackml/pkg/common/middleware/namespace"
@@ -35,7 +36,13 @@ func GetDashboards(c *fiber.Ctx) error {
 			),
 		).
 		Where("NOT dashboards.is_archived").
-		Order("dashboards.updated_at").
+		Order(clause.OrderByColumn{
+			Column: clause.Column{
+				Table: "App",
+				Name:  "updated_at",
+			},
+			Desc: true,
+		}).
 		Find(&dashboards).
 		Error; err != nil {
 		return fmt.Errorf("error fetching dashboards: %w", err)

--- a/tests/integration/golang/aim/dashboard/get_dashboards_test.go
+++ b/tests/integration/golang/aim/dashboard/get_dashboards_test.go
@@ -2,11 +2,13 @@ package run
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/G-Research/fasttrackml/pkg/api/aim/response"
+	"github.com/G-Research/fasttrackml/pkg/database"
 	"github.com/G-Research/fasttrackml/tests/integration/golang/helpers"
 )
 
@@ -42,6 +44,11 @@ func (s *GetDashboardsTestSuite) Test_Ok() {
 				context.Background(), s.DefaultNamespace, tt.expectedDashboardCount,
 			)
 			s.Require().Nil(err)
+
+			// Sort dashboards by App.UpdateAt time in descending order
+			slices.SortFunc(dashboards, func(a, b *database.Dashboard) int {
+				return b.App.UpdatedAt.Compare(a.App.UpdatedAt)
+			})
 
 			var resp []response.Dashboard
 			s.Require().Nil(s.AIMClient().WithResponse(&resp).DoRequest("/dashboards"))


### PR DESCRIPTION
This PR changes `GetDashboards` to sort the results by `App.UpdateAt` in reverse chronological order.

Fixes #728.