### PR TITLE
Fallback to a Python-compatible version identifier when no tags are present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ ifeq ($(shell go env GOOS),windows)
 endif
 # Version.
 VERSION?=$(shell git describe --tags --always --dirty --match='v*' 2> /dev/null | sed 's/^v//')
-# Enable Go Modules.
-GO111MODULE=on
 # Go ldflags.
 # Set version to git tag if available, otherwise use commit hash.
 # Strip debug symbols and disable DWARF generation.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ endif
 # Version.
 VERSION?=$(shell git describe --tags --always --dirty --match='v*' 2> /dev/null | sed 's/^v//')
 # Go ldflags.
-# Set version to git tag if available, otherwise use commit hash.
 # Strip debug symbols and disable DWARF generation.
 # Build static binaries on Linux.
 GO_LDFLAGS=-s -w -X github.com/G-Research/fasttrackml/pkg/version.Version=$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,12 @@ ifeq ($(shell go env GOOS),windows)
   APP:=$(APP).exe
 endif
 # Version.
-VERSION?=$(shell git describe --tags --always --dirty --match='v*' 2> /dev/null | sed 's/^v//')
+# Use git describe to get the version.
+# If the git describe fails, fallback to a version based on the git commit.
+VERSION?=$(shell git describe --tags --dirty --match='v*' 2> /dev/null | sed 's/^v//')
+ifeq ($(VERSION),)
+  VERSION=0.0.0-g$(shell git describe --always --dirty 2> /dev/null)
+endif
 # Go ldflags.
 # Strip debug symbols and disable DWARF generation.
 # Build static binaries on Linux.


### PR DESCRIPTION
Fixes #746 by implementing a fallback version identifier when no tags are present.

Also cleans up some unnecessary variables and comments in the Makefile.