### PR TITLE
Bump actions/download-artifact and actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,22 +293,22 @@ jobs:
           DOCKER_OUTPUT: type=oci,dest=fasttrackml-oci-${{ matrix.arch }}.tar
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: fasttrackml-archives
+          name: fasttrackml-archives-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*
 
       - name: Upload wheels artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: fasttrackml-wheels
+          name: fasttrackml-wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
       - name: Upload Docker artifact
         if: matrix.os == 'linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: fasttrackml-oci-images
+          name: fasttrackml-oci-images-${{ matrix.arch }}
           path: fasttrackml-oci-*.tar
 
   # Virtual job that can be configured as a required check before a PR can be merged.
@@ -338,9 +338,10 @@ jobs:
       packages: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: fasttrackml-oci-images
+          pattern: fasttrackml-oci-images-*
+          merge-multiple: true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,10 @@ jobs:
       id-token: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: fasttrackml-wheels
+          pattern: fasttrackml-wheels-*
+          merge-multiple: true
           path: wheelhouse
 
       - name: Publish package distributions to PyPI
@@ -35,9 +36,10 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: fasttrackml-archives
+          pattern: fasttrackml-archives-*
+          merge-multiple: true
           path: dist
 
       - name: Create release
@@ -89,9 +91,10 @@ jobs:
           echo "tags=${tags[@]}" >> $GITHUB_OUTPUT
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: fasttrackml-oci-images
+          pattern: fasttrackml-oci-images-*
+          merge-multiple: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Bump [`actions/download-artifact`](https://github.com/actions/download-artifact/tree/v4) and [`actions/upload-artifact`](https://github.com/actions/upload-artifact/tree/v4) from 3 to 4, which introduced [breaking changes](https://github.com/actions/upload-artifact/tree/v4#breaking-changes). We now explicitly upload different artifacts with different names and join them back together at download time.

This PR supersedes #751 and #752.