### PR TITLE
Helm chart - fasttrackml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
 
   chart-release:
     name: Publish Helm chart
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v') 
     uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,4 +125,4 @@ jobs:
     uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,11 @@ jobs:
             $(printf -- "--tag ${{ vars.DOCKER_REPO }}:%s " ${tags[@]}) \
             $(printf "${{ vars.DOCKER_REPO }}@%s " ${digests[@]})
           echo "::endgroup::"
+
+  chart-release:
+    name: Publish Helm chart
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    uses: G-Research/charts/.github/workflows/invoke-push.yaml@master
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.GH_APP_PEM }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ fml
 *.exe
 __debug_bin*
 
+# Helm chart
+!helm/**
+
 # Local database
 fasttrackml.db*
 encrypted.db*

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ fml
 *.exe
 __debug_bin*
 
-# Helm chart
-!helm/**
-
 # Local database
 fasttrackml.db*
 encrypted.db*

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,6 +47,14 @@ You can also run FastTrackML in a container via [Docker](https://docs.docker.com
 docker run --rm -p 5000:5000 -ti gresearch/fasttrackml
 ```
 
+### Deploy Helm chart
+
+You can also run FastTrackML in a Kubernetes via [Helm](https://helm.sh/docs/intro/install/):
+
+```bash
+helm install fasttrackml ./helm/fasttrackml
+```
+
 ### Verification
 
 Verify that you can see the UI by navigating to http://localhost:5000/.

--- a/helm/fasttrackml/.helmignore
+++ b/helm/fasttrackml/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/fasttrackml/Chart.yaml
+++ b/helm/fasttrackml/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: fasttrackml
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.4.0"

--- a/helm/fasttrackml/templates/_helpers.tpl
+++ b/helm/fasttrackml/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fasttrackml.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fasttrackml.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fasttrackml.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fasttrackml.labels" -}}
+helm.sh/chart: {{ include "fasttrackml.chart" . }}
+{{ include "fasttrackml.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fasttrackml.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fasttrackml.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fasttrackml.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fasttrackml.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/fasttrackml/templates/configMap.yaml
+++ b/helm/fasttrackml/templates/configMap.yaml
@@ -7,4 +7,4 @@ metadata:
   labels:
     {{- include "fasttrackml.labels" . | nindent 4 }}
 data:
-  {{- toYaml .Values.data | nindent 2 }}
+  {{- toYaml .Values.data |  nindent 2 }}

--- a/helm/fasttrackml/templates/configMap.yaml
+++ b/helm/fasttrackml/templates/configMap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fasttrackml.fullname" . }}-environment
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "fasttrackml.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.data | nindent 2 }}

--- a/helm/fasttrackml/templates/deployment.yaml
+++ b/helm/fasttrackml/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fasttrackml.fullname" . }}
+  labels:
+    {{- include "fasttrackml.labels" . | nindent 4 }}
+  namespace: {{ .Values.namespace }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fasttrackml.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fasttrackml.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "fasttrackml.fullname" . }}-environment
+          env:
+          {{- toYaml .Values.env | trim | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/fasttrackml/templates/ingress.yaml
+++ b/helm/fasttrackml/templates/ingress.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fasttrackml.fullname" . }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ingressClassName: {{ quote .Values.ingress.className }}
+  rules:
+  - http:
+      paths:
+      - path: {{ quote .Values.ingress.path }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ include "fasttrackml.fullname" . }}
+            port:
+              number: {{ .Values.service.port }}
+{{- end -}}

--- a/helm/fasttrackml/templates/service.yaml
+++ b/helm/fasttrackml/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fasttrackml.fullname" . }}
+  labels:
+    {{- include "fasttrackml.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fasttrackml.selectorLabels" . | nindent 4 }}

--- a/helm/fasttrackml/templates/tests/test-connection.yaml
+++ b/helm/fasttrackml/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "fasttrackml.fullname" . }}-test-connection"
+  labels:
+    {{- include "fasttrackml.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "fasttrackml.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/fasttrackml/values.yaml
+++ b/helm/fasttrackml/values.yaml
@@ -17,7 +17,8 @@ data:
 
   # common service settings.
   FML_DEV_MODE: "true"
-  FML_DATABASE_URI: "postgresql://admin:admin@localhost:5432" # /data/mydatabase.db
+  FML_DATABASE_URI: "postgresql://admin:admin@localhost:5432" # PostgresSQL
+  # FML_DATABASE_URI: "/data/mydatabase.db # SQLite 
   FML_LOG_LEVEL: "DEBUG"
 
   # database settings.
@@ -81,10 +82,6 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
   
-# For mounting SQLite database, set to `true` and uncoment `volumes` and `volumeMounts`
-sqlite:
-  enabled: false
-
 # Additional volumes on the output Deployment definition.
 volumes: []
   # - name: sqlite-db

--- a/helm/fasttrackml/values.yaml
+++ b/helm/fasttrackml/values.yaml
@@ -1,5 +1,6 @@
 ---
 replicaCount: 1
+namespace: default
 
 image:
   repository: gresearch/fasttrackml
@@ -12,22 +13,21 @@ nameOverride: ""
 fullnameOverride: ""
 
 data:
+  # NOTE: Make sure you qoute values for all keys
+
   # common service settings.
-  FML_DEV_MODE: true
-  FML_LOG_LEVEL: DEBUG
+  FML_DEV_MODE: "true"
+  FML_DATABASE_URI: "postgresql://admin:admin@localhost:5432" # /data/mydatabase.db
+  FML_LOG_LEVEL: "DEBUG"
 
   # database settings.
-  LC_COLLATE: POSIX
-  POSTGRES_USER: postgres
-  POSTGRES_PASSWORD: postgres
-  POSTGRES_DB: postgres
-  POSTGRES_HOSTNAME: localhost
+  LC_COLLATE: "POSIX"
 
   # s3 compatible storage settings.
-  AWS_ACCESS_KEY_ID: user
-  AWS_SECRET_ACCESS_KEY: password
-  FML_S3_ENDPOINT_URI: http://localhost:9000
-  FML_GS_ENDPOINT_URI: http://localhost:4443/storage/v1/
+  AWS_ACCESS_KEY_ID: "user"
+  AWS_SECRET_ACCESS_KEY: "password"
+  FML_S3_ENDPOINT_URI: "http://localhost:9000"
+  FML_GS_ENDPOINT_URI: "http://localhost:4443/storage/v1/"
 
 env: []
   # - name: MY_NODE_NAME
@@ -80,19 +80,21 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  
+# For mounting SQLite database, set to `true` and uncoment `volumes` and `volumeMounts`
+sqlite:
+  enabled: false
 
 # Additional volumes on the output Deployment definition.
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
+  # - name: sqlite-db
+  #   persistentVolumeClaim:
+  #     claimName: sqlite-pvc
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
+  # - name: sqlite-db
+  #   mountPath: /data
 
 nodeSelector: {}
 

--- a/helm/fasttrackml/values.yaml
+++ b/helm/fasttrackml/values.yaml
@@ -1,0 +1,101 @@
+---
+replicaCount: 1
+
+image:
+  repository: gresearch/fasttrackml
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+data:
+  # common service settings.
+  FML_DEV_MODE: true
+  FML_LOG_LEVEL: DEBUG
+
+  # database settings.
+  LC_COLLATE: POSIX
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
+  POSTGRES_DB: postgres
+  POSTGRES_HOSTNAME: localhost
+
+  # s3 compatible storage settings.
+  AWS_ACCESS_KEY_ID: user
+  AWS_SECRET_ACCESS_KEY: password
+  FML_S3_ENDPOINT_URI: http://localhost:9000
+  FML_GS_ENDPOINT_URI: http://localhost:4443/storage/v1/
+
+env: []
+  # - name: MY_NODE_NAME
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: spec.nodeName
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 5000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/fasttrackml/values.yaml
+++ b/helm/fasttrackml/values.yaml
@@ -18,7 +18,7 @@ data:
   # common service settings.
   FML_DEV_MODE: "true"
   FML_DATABASE_URI: "postgresql://admin:admin@localhost:5432" # PostgresSQL
-  # FML_DATABASE_URI: "/data/mydatabase.db # SQLite 
+  # FML_DATABASE_URI: "sqlite:///data/mydatabase.db" # SQLite 
   FML_LOG_LEVEL: "DEBUG"
 
   # database settings.

--- a/helm/fasttrackml/values.yaml
+++ b/helm/fasttrackml/values.yaml
@@ -54,6 +54,13 @@ service:
   type: ClusterIP
   port: 5000
 
+# By default ingress is enabled, and set to have `nginx` as `className`.
+# Change depending of your environment and needs
+ingress:
+  enabled: true
+  className: nginx
+  path: "/"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
The goal of this PR is to package FastTrackML and allow contributors to also use it inside a Kubernetes cluster with simple installation
The scope of change includes

- [x] using existing Docker Image as a base image for k8s deployment
  - [x] migrating [.env](https://github.com/ljubon/fasttrackml/blob/main/.devcontainer/.env) file to [ConfigMap](https://github.com/ljubon/fasttrackml/blob/3bfd8bb82d37dce56ec3f8ac95bfea76a99c16e5/helm/fasttrackml/values.yaml#L14) with exposing `data` section in default [values.yaml](https://github.com/ljubon/fasttrackml/blob/3bfd8bb82d37dce56ec3f8ac95bfea76a99c16e5/helm/fasttrackml/values.yaml#L14) file
- [x] publishing the helm chart to main G-Research/charts with the rest of the charts
  - [x] __NOTE__: For this action org owner will need to create secrets and follow process to onboard `fasttrackml` to this publishing  mehanism
  - [x] PR for adding `fastrackml` charts to the G-Research/config https://github.com/G-Research/charts/pull/130

#### Testing helm chart

```bash
git checkout oss-350-helm-chart-lvl-2
kind create cluster --name fastrackml
kubectl cluster-info --context kind-fastrackml
helm install fasttrackml ./helm/fasttrackml
kubectl port-forward deployment/fasttrackml 5000:5000

# Cleanup command
kind delete cluster --name fastrackml
```



In your local browser at http://localhost:5000 service will be exposed

Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/350