### PR TITLE
Bump actions used by `setup-go` to use Node 20

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - id: setup-go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: "1.21"
         check-latest: true
@@ -20,7 +20,7 @@ runs:
     - id: cache-info
       shell: bash
       run: echo path=$(go env GOCACHE) >> $GITHUB_OUTPUT
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ${{ steps.cache-info.outputs.path }}
         key: ${{ inputs.cache-prefix }}-go-${{ steps.setup-go.outputs.go-version }}-mod-${{ hashFiles('.go-build-tags', 'go.sum') }}


### PR DESCRIPTION
We are currently getting deprecation warnings in our CI:
![image](https://github.com/G-Research/fasttrackml/assets/3692455/ac4deaa8-acd2-45e3-8470-fb9633f82483)

This PR solves them via:
* Bump `actions/setup-go` from `v4` to `v5`
* Bump `actions/cache` from `v3` to `v4`

These 2 actions didn't get updated by Dependabot automatically, hence the manual update.