### PR TITLE
Alter context migration for Postgres efficiency (#941)

### DIFF
--- a/pkg/database/migrations/v_0009/migrate.go
+++ b/pkg/database/migrations/v_0009/migrate.go
@@ -3,10 +3,13 @@ package v_0009
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/rotisserie/eris"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/datatypes"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
 	"github.com/G-Research/fasttrackml/pkg/database/migrations"
@@ -17,62 +20,18 @@ const Version = "2c2299e4e061"
 func Migrate(db *gorm.DB) error {
 	return migrations.RunWithoutForeignKeyIfNeeded(db, func() error {
 		return db.Transaction(func(tx *gorm.DB) error {
-			// Rename the existing metrics tables and drop indexes
-			tablesIndexes := map[string][]string{
-				"metrics":        {"idx_metrics_run_id", "idx_metrics_iter"},
-				"latest_metrics": {"idx_latest_metrics_run_id"},
-			}
-			for table, indexes := range tablesIndexes {
-				for _, index := range indexes {
-					if err := dropIndex(tx, table, index); err != nil {
-						return eris.Wrapf(err, "error dropping %s", index)
-					}
+			switch tx.Dialector.Name() {
+			case sqlite.Dialector{}.Name():
+				err := sqliteMigrate(tx)
+				if err != nil {
+					return err
 				}
-				if err := tx.Migrator().RenameTable(table, backupName(table)); err != nil {
-					return eris.Wrapf(err, "error renaming %s", table)
+			case postgres.Dialector{}.Name():
+				err := postgresMigrate(tx)
+				if err != nil {
+					return err
 				}
 			}
-
-			// Auto-migrate to create new and altered tables
-			if err := tx.Migrator().AutoMigrate(&Context{}, &Metric{}, &LatestMetric{}); err != nil {
-				return eris.Wrap(err, "error automigrating new tables")
-			}
-
-			// Create the default metric context
-			defaultContext, err := createDefaultMetricContext(tx)
-			if err != nil {
-				return eris.Wrap(err, "error creating default metric context")
-			}
-
-			// Copy the data from the old tables to the new ones with default metric context
-			for table := range tablesIndexes {
-				// copy
-				if err := tx.Exec(fmt.Sprintf("INSERT INTO %s SELECT *, %d FROM %s",
-					table,
-					defaultContext.ID,
-					backupName(table))).Error; err != nil {
-					return eris.Wrapf(err, "error copying data for %s", table)
-				}
-
-				// verify
-				var oldRowCount, newRowCount int64
-				if err := tx.Table(table).Count(&newRowCount).Error; err != nil {
-					return eris.Wrapf(err, "error counting rows for %s", table)
-				}
-				if err := tx.Table(backupName(table)).Count(&oldRowCount).Error; err != nil {
-					return eris.Wrapf(err, "error counting rows for %s", backupName(table))
-				}
-				if oldRowCount != newRowCount {
-					return eris.Errorf("rowcount incorrect for %s (old: %d, new: %d)",
-						table, oldRowCount, newRowCount)
-				}
-
-				// Drop the backup tables
-				if err := tx.Exec("DROP TABLE " + backupName(table)).Error; err != nil {
-					return eris.Wrapf(err, "error dropping %s", backupName(table))
-				}
-			}
-
 			// Update the schema version
 			return tx.Model(&SchemaVersion{}).
 				Where("1 = 1").
@@ -80,6 +39,101 @@ func Migrate(db *gorm.DB) error {
 				Error
 		})
 	})
+}
+
+func sqliteMigrate(tx *gorm.DB) error {
+	tablesIndexes := map[string][]string{
+		"metrics":        {"idx_metrics_run_id", "idx_metrics_iter"},
+		"latest_metrics": {"idx_latest_metrics_run_id"},
+	}
+	for table, indexes := range tablesIndexes {
+		for _, index := range indexes {
+			if err := dropIndex(tx, table, index); err != nil {
+				return eris.Wrapf(err, "error dropping %s", index)
+			}
+		}
+		if err := tx.Migrator().RenameTable(table, backupName(table)); err != nil {
+			return eris.Wrapf(err, "error renaming %s", table)
+		}
+	}
+
+	if err := tx.Migrator().AutoMigrate(&Context{}, &Metric{}, &LatestMetric{}); err != nil {
+		return eris.Wrap(err, "error automigrating new tables")
+	}
+
+	defaultContext, err := createDefaultMetricContext(tx)
+	if err != nil {
+		return eris.Wrap(err, "error creating default metric context")
+	}
+
+	for table := range tablesIndexes {
+		if err := tx.Exec(fmt.Sprintf("INSERT INTO %s SELECT *, %d FROM %s",
+			table,
+			defaultContext.ID,
+			backupName(table))).Error; err != nil {
+			return eris.Wrapf(err, "error copying data for %s", table)
+		}
+
+		var oldRowCount, newRowCount int64
+		if err := tx.Table(table).Count(&newRowCount).Error; err != nil {
+			return eris.Wrapf(err, "error counting rows for %s", table)
+		}
+		if err := tx.Table(backupName(table)).Count(&oldRowCount).Error; err != nil {
+			return eris.Wrapf(err, "error counting rows for %s", backupName(table))
+		}
+		if oldRowCount != newRowCount {
+			return eris.Errorf("rowcount incorrect for %s (old: %d, new: %d)",
+				table, oldRowCount, newRowCount)
+		}
+
+		if err := tx.Exec("DROP TABLE " + backupName(table)).Error; err != nil {
+			return eris.Wrapf(err, "error dropping %s", backupName(table))
+		}
+	}
+	return nil
+}
+
+func postgresMigrate(tx *gorm.DB) error {
+	if err := tx.Migrator().AutoMigrate(&Context{}); err != nil {
+		return eris.Wrap(err, "error auto migrating context")
+	}
+	defaultMetricContext, err := createDefaultMetricContext(tx)
+	if err != nil {
+		return eris.Wrap(err, "error creating default metric context")
+	}
+
+	tablesKeyCols := map[string][]string{
+		"metrics":        {"key", "value", "timestamp", "run_uuid", "step", "is_nan", "context_id"},
+		"latest_metrics": {"key", "run_uuid", "context_id"},
+	}
+
+	for table, pkCols := range tablesKeyCols {
+		pk := fmt.Sprintf("%s_pkey", table)
+		if tx.Migrator().HasConstraint(table, pk) {
+			if err := tx.Migrator().DropConstraint(table, pk); err != nil {
+				return eris.Wrap(err, "error dropping primary key")
+			}
+		}
+
+		sql := fmt.Sprintf(`ALTER TABLE %s
+                        ADD COLUMN context_id BIGINT NOT NULL DEFAULT %d,
+                        ADD CONSTRAINT fk_%s_contexts FOREIGN KEY (context_id) REFERENCES contexts(id)`,
+			table, defaultMetricContext.ID, table)
+		if err := tx.Exec(sql).Error; err != nil {
+			return eris.Wrapf(err, "error adding context_id column for %s", table)
+		}
+
+		sql = fmt.Sprintf("ALTER TABLE %s ADD PRIMARY KEY (%s)", table, strings.Join(pkCols, ","))
+		if err := tx.Exec(sql).Error; err != nil {
+			return eris.Wrapf(err, "error creating pk for %s", table)
+		}
+
+		sql = fmt.Sprintf("ALTER TABLE %s ALTER COLUMN context_id DROP DEFAULT", table)
+		if err := tx.Exec(sql).Error; err != nil {
+			return eris.Wrapf(err, "error dropping default value for %s", table)
+		}
+	}
+	return nil
 }
 
 func backupName(name string) string {


### PR DESCRIPTION
* Separate migration approaches for Sqlite and Postgres for metric context -- for Postgres, we alter tables to add context_id, but for Sqlite we create anew. This allows the Postgres migration to run quickly on large data.

---------