### PR TITLE
Fix problem related to `docker-in-docker` feature in dev container.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2.9": {
 			"dockerDashComposeVersion": "none"
 		},
 		"ghcr.io/devcontainers/features/git:1": {},


### PR DESCRIPTION
What's inside the box:
- the latest version 2.* of `docker-in-docker` feature broke whole dev container. the latest stable version if 2.9.