### PR TITLE
Use Docker Compose v2 for container-based tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,13 @@ test-python-integration-aim: ## run the Aim python integration tests.
 container-test: ## run integration tests in container.
 	@echo ">>> Running integration tests in container."
 	@COMPOSE_FILE=$(COMPOSE_FILE) COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-		docker-compose run -e FML_RUN_ORIGINAL_AIM_SERVICE -e FML_SLOW_TESTS_ENABLED integration-tests
+		docker compose run -e FML_RUN_ORIGINAL_AIM_SERVICE -e FML_SLOW_TESTS_ENABLED integration-tests
 
 .PHONY: container-clean
 container-clean: ## clean containers.
 	@echo ">>> Cleaning containers."
 	@COMPOSE_FILE=$(COMPOSE_FILE) COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
-		docker-compose down -v --remove-orphans
+		docker compose down -v --remove-orphans
 
 #
 # Mockery targets.


### PR DESCRIPTION
The runner image for `ubuntu-22.04` has removed `docker-compose` in version `20240401.4.0` and it's [breaking our CI](https://github.com/G-Research/fasttrackml/actions/runs/8532040048/job/23372600776#step:1:9).

This PR fixes this by letting go of the deprecated `docker-compose` syntax in favour of `docker compose`.