### PR TITLE
Update `docker-in-docker` devcontainer feature and let go of workaround

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,7 +39,3 @@ COPY --from=tools /tmp/tools /usr/local/bin
 
 # Install xh
 RUN curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | XH_BINDIR=/usr/local/bin sh
-
-# Add docker-compose symlink to Docker Compose v2
-# This is a workaround until https://github.com/devcontainers/features/pull/621 lands
-RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,9 +41,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2.9": {
-			"dockerDashComposeVersion": "none"
-		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
https://github.com/devcontainers/features/issues/745 finally fixed the `docker-in-docker` devcontainer feature to use Docker Compose v2. Our workaround that was [installing it manually in the `Dockerfile`](https://github.com/G-Research/fasttrackml/blob/da0d04501eed0ce6351702f3751947ba789fec23/.devcontainer/Dockerfile#L43-L45) became obsolete, but it unfortunately broke the devcontainer. #1029 tried to fix it by pinning to an older version of the feature. This PR is proper fix that allows us to use a more recent version of the feature.