### PR TITLE
Change SearchMetrics endpoint to a POST

### DIFF
--- a/pkg/api/aim2/api/request/run.go
+++ b/pkg/api/aim2/api/request/run.go
@@ -58,11 +58,11 @@ type MetricTuple struct {
 // SearchMetricsRequest is a request struct for `GET /runs/search/metric` endpoint.
 type SearchMetricsRequest struct {
 	BaseSearchRequest
-	Metrics    []MetricTuple `query:"m"`
-	Query      string        `query:"q"`
-	Steps      int           `query:"p"`
-	XAxis      string        `query:"x_axis"`
-	SkipSystem bool          `query:"skip_system"`
+	Metrics    []MetricTuple `json:"m"`
+	Query      string        `json:"q"`
+	Steps      int           `json:"p"`
+	XAxis      string        `json:"x_axis"`
+	SkipSystem bool          `json:"skip_system"`
 }
 
 // SearchAlignedMetricsRequest is a request struct for `GET /runs/search/metric/align` endpoint.

--- a/pkg/api/aim2/api/request/run.go
+++ b/pkg/api/aim2/api/request/run.go
@@ -49,20 +49,14 @@ type SearchRunsRequest struct {
 	ExcludeTraces bool   `query:"exclude_traces"`
 }
 
-// MetricTuple represents a metric with key and context.
-type MetricTuple struct {
-	Key     string `query:"metric"`
-	Context string `query:"context"`
-}
-
 // SearchMetricsRequest is a request struct for `GET /runs/search/metric` endpoint.
 type SearchMetricsRequest struct {
 	BaseSearchRequest
-	Metrics    []MetricTuple `json:"m"`
-	Query      string        `json:"q"`
-	Steps      int           `json:"p"`
-	XAxis      string        `json:"x_axis"`
-	SkipSystem bool          `json:"skip_system"`
+	Metrics    [][]string `json:"metrics"`
+	Query      string     `json:"query"`
+	Steps      int        `json:"steps"`
+	XAxis      string     `json:"x_axis"`
+	SkipSystem bool       `json:"skip_system"`
 }
 
 // SearchAlignedMetricsRequest is a request struct for `GET /runs/search/metric/align` endpoint.

--- a/pkg/api/aim2/controller/runs.go
+++ b/pkg/api/aim2/controller/runs.go
@@ -127,7 +127,7 @@ func (c Controller) SearchRuns(ctx *fiber.Ctx) error {
 	return nil
 }
 
-// SearchMetrics handles `GET /runs/search/metric` endpoint.
+// SearchMetrics handles `POST /runs/search/metric` endpoint.
 func (c Controller) SearchMetrics(ctx *fiber.Ctx) error {
 	ns, err := middleware.GetNamespaceFromContext(ctx.Context())
 	if err != nil {
@@ -136,10 +136,9 @@ func (c Controller) SearchMetrics(ctx *fiber.Ctx) error {
 	log.Debugf("searchMetrics namespace: %s", ns.Code)
 
 	req := request.SearchMetricsRequest{}
-	if err = ctx.QueryParser(&req); err != nil {
+	if err = ctx.BodyParser(&req); err != nil {
 		return fiber.NewError(fiber.StatusUnprocessableEntity, err.Error())
 	}
-
 	if ctx.Query("report_progress") == "" {
 		req.ReportProgress = true
 	}
@@ -163,7 +162,7 @@ func (c Controller) SearchMetrics(ctx *fiber.Ctx) error {
 	return nil
 }
 
-// SearchAlignedMetrics handles `GET /runs/search/metric/align` endpoint.
+// SearchAlignedMetrics handles `POST /runs/search/metric/align` endpoint.
 func (c Controller) SearchAlignedMetrics(ctx *fiber.Ctx) error {
 	ns, err := middleware.GetNamespaceFromContext(ctx.Context())
 	if err != nil {

--- a/pkg/api/aim2/dao/repositories/metric.go
+++ b/pkg/api/aim2/dao/repositories/metric.go
@@ -178,7 +178,7 @@ func (r MetricRepository) SearchMetrics(
 
 	var metricKeyContextConditionSlice []string
 	for i, tuple := range req.Metrics {
-		condition := fmt.Sprintf("(latest_metrics.key = '%s' AND contexts.id = %d)", tuple.Key, ids[i])
+		condition := fmt.Sprintf("(latest_metrics.key = '%s' AND contexts.id = %d)", tuple[0], ids[i])
 		metricKeyContextConditionSlice = append(metricKeyContextConditionSlice, condition)
 	}
 	metricKeyContextCondition := strings.Join(metricKeyContextConditionSlice, " OR ")
@@ -256,7 +256,7 @@ func (r MetricRepository) findContextIDs(ctx context.Context, req *request.Searc
 	contextList := []types.JSONB{}
 	contextsMap := map[string]types.JSONB{}
 	for _, r := range req.Metrics {
-		data := types.JSONB(r.Context)
+		data := types.JSONB(r[1])
 		contextList = append(contextList, data)
 		contextsMap[string(data)] = data
 	}

--- a/pkg/api/aim2/routes.go
+++ b/pkg/api/aim2/routes.go
@@ -65,7 +65,7 @@ func (r Router) Init(server fiber.Router) {
 	runs := mainGroup.Group("/runs")
 	runs.Get("/active/", r.controller.GetRunsActive)
 	runs.Get("/search/run/", r.controller.SearchRuns)
-	runs.Get("/search/metric/", r.controller.SearchMetrics)
+	runs.Post("/search/metric/", r.controller.SearchMetrics)
 	runs.Post("/search/metric/align/", r.controller.SearchAlignedMetrics)
 	runs.Get("/:id/info/", r.controller.GetRunInfo)
 	runs.Post("/:id/metric/get-batch/", r.controller.GetRunMetrics)


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/1053.
Change the `SearchMetrics` endpoint from a `GET` to a `POST`