### PR TITLE
chore: CI - Fix cache key computation in Go integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Compute cache info
         id: cache-info
         run: |
-          image=$(yq .services.service.image < tests/integration/docker-compose.yml)
+          image=$(yq .services.integration-tests.image < tests/integration/docker-compose.yml)
           echo go-version=$(skopeo inspect docker://${image} | jq -r .Digest | cut -d: -f2) >> $GITHUB_OUTPUT
 
       - name: Setup cache


### PR DESCRIPTION
The cache key was not computed correctly for the Go integration tests in our CI since #687. This PR fixes that.