### PR TITLE
Performance improvement for `GET /projects/params` endpoint.

### DIFF
--- a/pkg/api/aim2/services/project/service.go
+++ b/pkg/api/aim2/services/project/service.go
@@ -104,7 +104,7 @@ func (s Service) GetProjectParams(
 	}
 
 	if slices.Contains(req.Sequences, "metric") {
-		metrics, err := s.metricRepository.GetLatestMetricsByExperiments(ctx, namespaceID, req.Experiments)
+		metrics, err := s.metricRepository.GetMetricKeysAndContextsByExperiments(ctx, namespaceID, req.Experiments)
 		if err != nil {
 			return nil, api.NewInternalError("error getting metrics: %s", err)
 		}


### PR DESCRIPTION
What inside the box:
- we have a performance degradation for `GET /projects/params` endpoint when we select metrics data. Instead of selecting all the fields, select just only important `key` + `context_id` in distinct mode.