### PR TITLE
Fix python-integration-tests name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
 
   python-integration-tests:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
-    name: Python Integration Tests (${{ matrix.api }})
+    name: Python Integration Tests (${{ matrix.test-targets }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR fixes the missing part from the name of `python-integration-tests` job names. `api` was being picked up from the matrix, which doesn't exists, which made github print out empty parenthesis in the job name. Matrix defines 'test-targets' instead. 

Ran into this accidentally, saw an opportunity and fixed it (boy scout rule).

Working example: https://github.com/pavlovic-ivan/fasttrackml/actions/runs/9207382745