### PR TITLE
Store the Run Description as a tag

### DIFF
--- a/pkg/api/aim/dao/repositories/tag.go
+++ b/pkg/api/aim/dao/repositories/tag.go
@@ -18,6 +18,8 @@ type TagRepositoryProvider interface {
 	GetTagsByNamespace(ctx context.Context, namespaceID uint) ([]models.Tag, error)
 	// CreateExperimentTag creates new models.ExperimentTag entity connected to models.Experiment.
 	CreateExperimentTag(ctx context.Context, experimentTag *models.ExperimentTag) error
+	// CreateRunTag creates new models.Tag entity connected to models.Run.
+	CreateRunTag(ctx context.Context, runTag *models.Tag) error
 	// GetTagKeysByParameters returns list of tag keys by requested parameters.
 	GetTagKeysByParameters(ctx context.Context, namespaceID uint, experiments []int) ([]string, error)
 }
@@ -40,6 +42,20 @@ func (r TagRepository) CreateExperimentTag(ctx context.Context, experimentTag *m
 		UpdateAll: true,
 	}).Create(experimentTag).Error; err != nil {
 		return eris.Wrapf(err, "error creating tag for experiment with id: %d", experimentTag.ExperimentID)
+	}
+	return nil
+}
+
+// CreateRunTagn creates new models.Tag entity connected to models.Run.
+func (r TagRepository) CreateRunTag(ctx context.Context, runTag *models.Tag) error {
+	if err := r.GetDB().WithContext(ctx).Clauses(clause.OnConflict{
+		UpdateAll: true,
+	}).Create([]models.Tag{{
+		Key:   runTag.Key,
+		Value: runTag.Value,
+		RunID: runTag.RunID,
+	}}).Error; err != nil {
+		return eris.Wrapf(err, "error creating tag for run with id: %s", runTag.RunID)
 	}
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -279,6 +279,7 @@ func createApp(
 			aimRunService.NewService(
 				aimRepositories.NewRunRepository(db.GormDB()),
 				aimRepositories.NewMetricRepository(db.GormDB()),
+				aimRepositories.NewTagRepository(db.GormDB()),
 			),
 			aimProjectService.NewService(
 				aimRepositories.NewTagRepository(db.GormDB()),


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/373.
When we receive a description during a run update, we create a new run tag with key `mlflow.note.content` which is the way MlFlow uses to store the run description