### PR TITLE
(bugfix) Make Experiments Overview Page Show Dates & Runs

### DIFF
--- a/pkg/api/aim/api/response/experiment.go
+++ b/pkg/api/aim/api/response/experiment.go
@@ -43,8 +43,8 @@ func NewGetExperimentsResponse(experiments []models.ExperimentExtended) []Experi
 type ExperimentRunPartial struct {
 	ID           string `json:"run_id"`
 	Name         string `json:"name"`
-	CreationTime int64  `json:"creationTime"`
-	EndTime      int64  `json:"endTime"`
+	CreationTime int64  `json:"creation_time"`
+	EndTime      int64  `json:"end_time"`
 	Archived     bool   `json:"archived"`
 }
 

--- a/pkg/api/aim/dao/repositories/run.go
+++ b/pkg/api/aim/dao/repositories/run.go
@@ -398,16 +398,22 @@ func (r RunRepository) SearchRuns(
 
 	log.Debugf("Total runs: %d", total)
 
+	experimentsSelect := database.DB.Select(
+		"ID", "Name",
+	).Where(
+		&models.Experiment{NamespaceID: namespaceID},
+	)
+	// Do not include the filter if there are no ExperimentNames
+	if len(req.ExperimentNames) > 0 {
+		experimentsSelect = experimentsSelect.Where(
+			`"Experiment"."name" IN ?`, req.ExperimentNames,
+		)
+	}
+
 	tx := r.GetDB().WithContext(ctx).
 		InnerJoins(
 			"Experiment",
-			database.DB.Select(
-				"ID", "Name",
-			).Where(
-				&models.Experiment{NamespaceID: namespaceID},
-			).Where(
-				`"Experiment"."name" IN ?`, req.ExperimentNames,
-			),
+			experimentsSelect,
 		).
 		Order("row_num DESC")
 


### PR DESCRIPTION
# Date fix
The server is sending data in camel case which causes the experiment overview page to show invalid date instead of the actual date. The expected data type is here:  https://github.com/G-Research/fasttrackml-ui-aim/blob/release/v3.17.5/src/src/modules/core/api/experimentsApi/types.ts#L84-L90 

Before the change
![Screenshot from 2024-08-01 17-58-25](https://github.com/user-attachments/assets/cb09da0e-373e-462f-9a86-258c46da1547)


After the change
![Screenshot from 2024-08-01 17-58-51](https://github.com/user-attachments/assets/9bde935c-ee9c-413d-a1f6-0355f30edf2b)

# Runs fix
When you click the runs tab it make an API call to the AIM end points for `GET /runs/search/run`. The UI's code sets the experiment as a query see:
https://github.com/G-Research/fasttrackml-ui-aim/blob/release/v3.17.5/src/src/pages/Experiment/components/ExperimentRunsTab/ExperimentRunsTable/useExperimentRunsTable.tsx#L224-L228

If `ExperimentNames`is empty it shouldn't be included in the query on the DB. 