### PR TITLE
Add multiarch image digest for attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,8 @@ jobs:
             $(printf -- "--tag ${{ vars.DOCKER_REPO }}:%s " ${tags[@]}) \
             $(printf "${{ vars.DOCKER_REPO }}@%s " ${digests[@]})
           echo "::endgroup::"
+          multiarch_digest=$(docker buildx imagetools inspect ${{ vars.DOCKER_REPO }}:${tags[0]} --format '{{json .}}' | jq -r '.manifest.digest')
+          digests+=($multiarch_digest)
           # Output digests as a JSON array for use in a matrix
           echo "digests=$(printf '%s\n' "${digests[@]}" | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
This PR adds the multiarch image digest to the array of digests, later used for attestations. 

Note: grabbed the first tag (`${tags[0]}`) from the `tags` array because `inspect` will return the same manifest. I can't use multiple args/tags for `inspect` the way they are used in `create`.