### PR TITLE
Mention mlflow-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ ships with the visualization UI of both MLflow and Aim.
 As the name implies, the emphasis is on speed -- fast logging, fast
 retrieval.
 
+## mlflow-go
+
+> [!TIP]
+> We are excited to be developing the next evolution of performant experiment tracking at [mlflow/mlflow-go-backend](https://github.com/mlflow/mlflow-go-backend)!
+
 ### Quickstart
 
 #### Run the tracking server

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -163,9 +163,9 @@ module.exports = async function configCreatorAsync() {
                 },
                 announcementBar: {
                     // https://docusaurus.io/docs/api/themes/configuration#announcement-bar
-                    id: `announcement-bar-${releaseVersion}`,
-                    content: `FastTrackML ${releaseVersion} has been <a href="${releaseUrl}" target="_blank">released</a>!`,
-                    isCloseable: true,
+                    id: `announcement-bar-mlflow-go`,
+                    content: `We are excited to introduce <a href="https://github.com/mlflow/mlflow-go-backend" target="_blank">mlflow-go</a>, the successor of FastTrackML!`,
+                    isCloseable: false
                 },
                 colorMode: {
                     defaultMode: 'light',


### PR DESCRIPTION
We wish to lure FastTrackML users to our new https://github.com/mlflow/mlflow-go-backend project.

@naskio did I got that website setting right?

![image](https://github.com/user-attachments/assets/f38f407a-b400-4f34-beaa-e7dc4825cc80)
