### PR TITLE
Disable PyPI attestations as they prevent publishing to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse
+          # this is _not_ GitHub attestations and must be disabled to work with reusable workflows
+          attestations: false
 
   github-release:
     name: Publish GitHub release


### PR DESCRIPTION
We use reusable workflows, which clash with PyPI attestations, so we have to disable them (we never used them and they got introduced in a newer version of the PyPI publishing action we use).
